### PR TITLE
docs: restructure readmes and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Example applications built with [Arcium](https://arcium.com), the encrypted compute
 network on Solana. Each example computes on encrypted data using multi-party
-computation (MPC): inputs stay encrypted end to end, and no single party, including
-the nodes running the computation, ever sees them.
+computation (MPC): confidential inputs stay encrypted end to end, and no compute
+node sees them in plaintext.
 
 ## How Arcium works
 
-Every example follows the same lifecycle:
+The examples share the same computation lifecycle:
 
-1. The client encrypts inputs locally (x25519 key exchange + RescueCipher) and
-   submits them in a Solana transaction.
+1. The client submits plaintext or locally encrypted inputs. Confidential client
+   inputs use x25519 key exchange and `RescueCipher`.
 2. The Anchor program queues a computation with the Arcium program.
 3. An MPC cluster executes the encrypted instruction defined in `encrypted-ixs/`.
 4. The result returns on-chain via a callback instruction, which stores or reveals it.
@@ -30,9 +30,9 @@ Recommended path: work through them in order. Each introduces one new pattern.
 | [Rock Paper Scissors](./rock_paper_scissors/) | Hidden moves | Yes ([vs player](./rock_paper_scissors/against-player/)), No ([vs house](./rock_paper_scissors/against-house/)) | `Enc<Shared, T>` inputs, RNG opponent |
 | [Voting](./voting/) | Private aggregation | Yes | `Enc<Mxe, T>` accumulators, callbacks |
 | [Medical Records](./share_medical_records/) | Controlled sharing | Yes | Re-encryption to a new owner |
-| [Sealed-Bid Auction](./sealed_bid_auction/) | Encrypted comparison | Yes | First-price and Vickrey settlement |
+| [Sealed-Bid Auction](./sealed_bid_auction/) | Encrypted comparison | Yes | First-price and Vickrey clearing prices |
 | [Blackjack](./blackjack/) | Hidden game state | Yes | `Pack<T>` storage efficiency |
-| [Ed25519 Signatures](./ed25519/) | Distributed signing | Yes | Keys that never exist in one place |
+| [Ed25519 Signatures](./ed25519/) | Distributed signing | No | Keys that never exist in one place |
 
 ## Running an example
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,79 @@
-# Arcium Examples 
+# Arcium Examples
 
-Applications built on public blockchains face a fundamental limitation: all computation is transparent. These examples demonstrate how to build applications that can compute on confidential data.
+Example applications built with [Arcium](https://arcium.com), the encrypted compute
+network on Solana. Each example computes on encrypted data using multi-party
+computation (MPC): inputs stay encrypted end to end, and no single party, including
+the nodes running the computation, ever sees them.
 
-## Getting Started
+## How Arcium works
 
-For installation instructions and setup, see the [Installation Guide](https://docs.arcium.com/developers/installation).
+Every example follows the same lifecycle:
+
+1. The client encrypts inputs locally (x25519 key exchange + RescueCipher) and
+   submits them in a Solana transaction.
+2. The Anchor program queues a computation with the Arcium program.
+3. An MPC cluster executes the encrypted instruction defined in `encrypted-ixs/`.
+4. The result returns on-chain via a callback instruction, which stores or reveals it.
+
+Data stays private as long as one node in the cluster is honest; the protocol
+tolerates a dishonest majority. See [Core Concepts](https://docs.arcium.com/developers/core-concepts)
+and [Computation Lifecycle](https://docs.arcium.com/developers/computation-lifecycle)
+for the full picture.
 
 ## Examples
 
-New to Arcium? Start with Coinflip and progress through the tiers in order. For conceptual background, see [Mental Model](https://docs.arcium.com/developers/arcis/mental-model).
+Recommended path: work through them in order. Each introduces one new pattern.
 
-### Getting Started
+| Example | Pattern | Encrypted on-chain state | Main concept |
+|---|---|---|---|
+| [Coinflip](./coinflip/) | Trustless randomness | No | `ArcisRNG`, revealing results |
+| [Rock Paper Scissors](./rock_paper_scissors/) | Hidden moves | Yes ([vs player](./rock_paper_scissors/against-player/)), No ([vs house](./rock_paper_scissors/against-house/)) | `Enc<Shared, T>` inputs, RNG opponent |
+| [Voting](./voting/) | Private aggregation | Yes | `Enc<Mxe, T>` accumulators, callbacks |
+| [Medical Records](./share_medical_records/) | Controlled sharing | Yes | Re-encryption to a new owner |
+| [Sealed-Bid Auction](./sealed_bid_auction/) | Encrypted comparison | Yes | First-price and Vickrey settlement |
+| [Blackjack](./blackjack/) | Hidden game state | Yes | `Pack<T>` storage efficiency |
+| [Ed25519 Signatures](./ed25519/) | Distributed signing | Yes | Keys that never exist in one place |
 
-**[Coinflip](./coinflip/)** - Generate trustless randomness using `ArcisRNG`. Stateless design, simplest example.
+## Running an example
 
-**[Rock Paper Scissors](./rock_paper_scissors/)** - Encrypted asynchronous gameplay with hidden moves.
-- [Player vs Player](./rock_paper_scissors/against-player/) - Two encrypted submissions
-- [Player vs House](./rock_paper_scissors/against-house/) - Provably fair randomized opponent
+Prerequisites: the [Arcium CLI](https://docs.arcium.com/developers/installation),
+which requires Rust, the Solana CLI, Anchor, and Docker. Toolchain versions are
+pinned per example in `Cargo.toml` and `rust-toolchain.toml`.
 
-### Intermediate
+Every example builds and tests the same way:
 
-**[Voting](./voting/)** - Private ballots with public results. Encrypted state accumulation and callbacks.
+```bash
+cd voting        # or any example
+yarn install
+arcium build     # compiles the encrypted circuit and the Anchor program
+arcium test      # runs the tests against a local Arcium cluster
+```
 
-**[Medical Records](./share_medical_records/)** - Patient-controlled data sharing via re-encryption.
+Each example has the same layout:
 
-**[Sealed-Bid Auction](./sealed_bid_auction/)** - Encrypted bid comparison with first-price and Vickrey mechanisms.
+```
+encrypted-ixs/   # Arcis circuit: the code that runs inside MPC
+programs/        # Anchor program: queues computations, handles callbacks
+tests/           # TypeScript tests: encryption happens client-side here
+```
 
-### Advanced
+## Troubleshooting
 
-**[Blackjack](./blackjack/)** - Hidden deck state with `Pack<T>` for efficient encrypted storage.
-
-**[Ed25519 Signatures](./ed25519/)** - Distributed key management. Private keys never exist in single location.
+- **`arcium test` hangs at keygen after a version bump**: stale localnet cache.
+  Remove `artifacts/localnet/mxe_utility_pubkeys.bin` and
+  `artifacts/localnet/private_shares_node_*`, then rerun.
+- **Computation stuck in `queued`**: the local cluster did not finalize; rerun the
+  test. Persistent failures usually mean the circuit and program are out of sync:
+  run `arcium build` again.
+- **`AbortedComputation` in a callback**: the MPC output failed verification. Check
+  that the argument order in the queue call matches the circuit signature exactly.
 
 ## Documentation
 
-- [Mental Model](https://docs.arcium.com/developers/arcis/mental-model) - Conceptual foundation
-- [Computation Lifecycle](https://docs.arcium.com/developers/computation-lifecycle) - How MPC computations execute
-- [Arcis Framework](https://docs.arcium.com/developers/arcis) - Programming model reference
-- [Best Practices](https://docs.arcium.com/developers/arcis/best-practices) - Performance optimization
+[Mental Model](https://docs.arcium.com/developers/arcis/mental-model) ·
+[Arcis reference](https://docs.arcium.com/developers/arcis) ·
+[Best Practices](https://docs.arcium.com/developers/arcis/best-practices) ·
+[Discord](https://discord.com/invite/arcium)
 
-For questions and support, join the [Discord community](https://discord.com/invite/arcium).
+These examples are for learning. They are not audited and cut corners a production
+deployment must not; see each example's Limitations section.

--- a/blackjack/README.md
+++ b/blackjack/README.md
@@ -1,138 +1,65 @@
-# Blackjack - Hidden Game State
+# Blackjack — hidden game state
 
-Physical blackjack naturally hides the dealer's hole card. Digital blackjack has a different problem: the card's value must be stored somewhere - whether that's on a game server, in a database, or in code. Trusting a server to "hide" it just means betting they won't peek.
+A single-player blackjack game where the shuffled deck and the dealer's hole card exist only as ciphertext.
+MPC nodes shuffle and deal inside the computation; the player decrypts only their own hand and the dealer's
+face-up card, and no server, node, or chain observer can peek at undealt cards.
 
-This example shows how to implement blackjack where cards remain encrypted until they need to be revealed according to game rules.
+**Use this pattern when** encrypted state must persist on-chain across many turns with rule-driven selective
+reveals: card games, fog-of-war strategy, any turn-based game with private state.
 
-## Why is hidden information hard in digital card games?
+## How it works
 
-Physical blackjack maintains three types of hidden information: the dealer's hole card, undealt cards in the deck, and random shuffle order. In digital implementations, this information must be stored as data - whether on a server or on a public blockchain - where it becomes vulnerable to inspection or manipulation.
+1. `initialize_blackjack_game` creates the `BlackjackGame` PDA and queues `shuffle_and_deal_cards`, which
+   shuffles a 52-card deck with `ArcisRNG::shuffle` and deals two cards each: deck and dealer hand return as
+   `Enc<Mxe, ...>` (decryptable by no one), player hand and dealer face-up card as `Enc<Shared, ...>`
+   (decryptable only by the player).
+2. The callback stores every ciphertext in `BlackjackGame` and emits `CardsShuffledAndDealtEvent`; the
+   player decrypts their hand client-side.
+3. `player_hit` and `player_double_down` feed the stored deck and hand ciphertexts back into MPC by byte
+   offset (`ArgBuilder`), draw the next card, and reveal only a bust boolean. `player_stand` ends the turn.
+4. `dealer_play` draws against the encrypted deck inside MPC until reaching 17, then returns the dealer hand
+   re-encrypted to both the MXE and the player.
+5. `resolve_game` compares both hands inside MPC and reveals a single result code.
 
-Blockchain implementations face an additional challenge: transparent state. If card data is stored on-chain unencrypted, all participants can view the dealer's hidden cards and remaining deck order, completely breaking the game.
+Everyone sees hand sizes, `GameState` transitions, bust flags, and the final winner; only the player sees
+card values; nobody ever sees the undealt deck.
 
-## How Hidden Game State Works
+## Concepts demonstrated
 
-At game initialization, a 52-card deck is shuffled using Arcium's cryptographic randomness. The entire deck, including player cards and the dealer's hole card, remains encrypted throughout gameplay.
+- Packed encrypted state: `Pack<[u8; 52]>` fits the whole deck into two ciphertexts. Size math is in the
+  module header of `programs/blackjack/src/lib.rs`; see
+  [Data packing](https://docs.arcium.com/developers/arcis/primitives#data-packing).
+- Reading encrypted account state back into computations: each action passes stored ciphertexts via
+  `ArgBuilder` account references instead of re-uploading them.
+- A multi-computation state machine: `GameState` gates which of the six circuits may run.
+- [`ArcisRNG::shuffle`](https://docs.arcium.com/developers/arcis/primitives#shuffling): unbiased deck order
+  no party can predict.
 
-Information disclosure follows game rules: players view their own cards and the dealer's face-up card. Game actions (hit, stand, double down) are processed against encrypted hand values. The dealer's hole card and undealt cards remain encrypted until game resolution.
-
-## Running the Example
+## Run
 
 ```bash
-# Install dependencies
-yarn install  # or npm install or pnpm install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite demonstrates a complete game flow: deck shuffling with secure randomness, dealing encrypted cards, processing game actions against hidden state, and verifying final game result.
+Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-The deck is stored as encrypted values, with multiple cards packed together for efficiency. Game logic processes encrypted hand values without ever decrypting them, using Arcium's confidential instructions.
+- `encrypted-ixs/src/lib.rs` — note how one circuit returns both `Enc<Mxe, ...>` and `Enc<Shared, ...>` outputs.
+- `programs/blackjack/src/lib.rs` — note how actions rebuild circuit inputs from stored ciphertexts by byte offset.
+- `tests/blackjack.ts` — note how `unpackHand` shifts cards out of a decrypted field element to read a `Pack`'d hand.
 
-The system works through three key mechanisms: network-generated randomness creates unpredictable deck order, selective disclosure reveals only authorized information per game rules, and the MPC protocol ensures no party can manipulate game state or outcomes even with a dishonest majority—game integrity is preserved as long as one node is honest.
+## Pitfalls
 
-## Implementation Details
+- `ArgBuilder` argument order and byte offsets must match the circuit signature and the `BlackjackGame`
+  field layout exactly; offsets count from the 8-byte discriminator (deck 8, player hand 72, dealer 104).
+- `InvalidGameState`: each action checks the state machine; `dealer_play` before a stand or bust is rejected.
+- `InvalidMove`: hitting after standing, or growing a hand past the 11-card `Hand` capacity.
 
-### The Encryption Size Problem
+## Limitations
 
-**Requirement**: Encrypt a deck of 52 playing cards for an on-chain Blackjack game.
+- Hand sizes, bust flags, and the winner are public: observers see exactly when the player busts.
+- The dealer's face-up card is encrypted to the player rather than published, unlike real blackjack.
+- No bets, splits, insurance, or multiplayer, and no timeout path for abandoned games.
 
-**Naive Approach**: Store each card as a separate encrypted value.
-
-- Each card can be represented as `u8` (values 0-51)
-- 52 cards = 52 `u8` values
-- After encryption: each `u8` becomes a 32-byte ciphertext
-- **Total size**: 52 x 32 bytes = **1,664 bytes**
-
-**The Problem**: Solana's transaction size limit is **1,232 bytes**, but our encrypted deck is 1,664 bytes. Whether returning the generated deck from initialization or passing it in transactions to deal more cards, the deck won't fit in a single transaction.
-
-### The Solution: `Pack<T>`
-
-Arcis provides `Pack<T>`, a built-in type that compresses byte arrays into fewer field elements for encryption. Instead of encrypting each card individually, `Pack` packs multiple bytes into a single field element.
-
-**How it works**:
-
-- Each field element holds up to 26 bytes (at 8 bits per byte)
-- `Pack<[u8; 52]>` = 52 bytes / 26 bytes per element = **2 field elements**
-- `Pack<[u8; 11]>` = 11 bytes / 26 bytes per element = **1 field element**
-
-**Usage in the circuit**:
-
-```rust
-type Deck = Pack<[u8; 52]>;
-type Hand = Pack<[u8; 11]>;
-
-let deck_packed: Deck = Pack::new(initial_deck);
-let deck = Mxe::get().from_arcis(deck_packed);
-```
-
-**After encryption**:
-
-- 2 field elements -> 2 x 32 bytes = **64 bytes**
-- **Savings**: 1,664 bytes -> 64 bytes (96% reduction)
-
-Accessing individual cards requires unpacking first:
-
-```rust
-let deck_array = deck_ctxt.to_arcis().unpack();
-let card = deck_array[index];
-```
-
-### Account Storage Structure
-
-On-chain storage uses serialized byte arrays. Encrypted `Pack` values are stored as `[u8; 32]` ciphertexts:
-
-```rust
-pub struct BlackjackGame {
-    pub deck: [[u8; 32]; 2],      // Pack<[u8; 52]> = 2 field elements
-    pub player_hand: [u8; 32],    // Pack<[u8; 11]> = 1 field element
-    pub dealer_hand: [u8; 32],    // Pack<[u8; 11]> = 1 field element
-    pub deck_nonce: u128,         // Nonce for deck encryption
-    pub client_nonce: u128,       // Nonce for player hand
-    pub dealer_nonce: u128,       // Nonce for dealer hand
-    pub player_hand_size: u8,     // How many cards actually in player_hand
-    pub dealer_hand_size: u8,     // How many cards actually in dealer_hand
-    // ... other game state
-}
-```
-
-**Why separate nonces?** Each encrypted value needs its own nonce for security.
-
-**Why track hand sizes?** The packed hand can hold up to 11 cards, but we need to know how many are actually present (could be 2, 3, 10, etc.).
-
-### The Result
-
-**Without packing**:
-
-- Deck: 52 encrypted values (1,664 bytes)
-- Player hand: 11 encrypted values (352 bytes)
-- Dealer hand: 11 encrypted values (352 bytes)
-- **Total**: 2,368 bytes (won't fit in Solana transaction or account efficiently)
-
-**With `Pack<T>`**:
-
-- Deck: 2 encrypted values (64 bytes)
-- Player hand: 1 encrypted value (32 bytes)
-- Dealer hand: 1 encrypted value (32 bytes)
-- **Total**: 128 bytes
-
-**Additional benefits**:
-
-- Fewer MPC operations (4 encryptions vs 74)
-- Faster computation (less encrypted data to process)
-- Lower costs (fewer computation units)
-- No manual encoding/decoding logic needed
-
-> For more optimization techniques, see [Best Practices](https://docs.arcium.com/developers/arcis/best-practices).
-
-### When to Use This Pattern
-
-Use `Pack<T>` when you have arrays of small values that are processed together. Arcis handles the packing and unpacking automatically — define a type alias, and the framework manages compression.
-
-Examples: game pieces, map tiles, bit flags, small integers, inventory items.
+See also: [Arcis best practices](https://docs.arcium.com/developers/arcis/best-practices) · **Next:** [Ed25519](../ed25519/)

--- a/blackjack/README.md
+++ b/blackjack/README.md
@@ -11,7 +11,7 @@ reveals: card games, fog-of-war strategy, any turn-based game with private state
 
 1. `initialize_blackjack_game` creates the `BlackjackGame` PDA and queues `shuffle_and_deal_cards`, which
    shuffles a 52-card deck with `ArcisRNG::shuffle` and deals two cards each: deck and dealer hand return as
-   `Enc<Mxe, ...>` (decryptable by no one), player hand and dealer face-up card as `Enc<Shared, ...>`
+   `Enc<Mxe, ...>` (not decryptable by any single party), player hand and dealer face-up card as `Enc<Shared, ...>`
    (decryptable only by the player).
 2. The callback stores every ciphertext in `BlackjackGame` and emits `CardsShuffledAndDealtEvent`; the
    player decrypts their hand client-side.
@@ -60,6 +60,7 @@ Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
 - Hand sizes, bust flags, and the winner are public: observers see exactly when the player busts.
 - The dealer's face-up card is encrypted to the player rather than published, unlike real blackjack.
+- Actions must finalize sequentially: their nonces and hand sizes are fixed when queueing while account ciphertexts are fetched during computation, so overlapping actions can use incompatible state versions or overwrite an update.
 - No bets, splits, insurance, or multiplayer, and no timeout path for abandoned games.
 
 See also: [Arcis best practices](https://docs.arcium.com/developers/arcis/best-practices) · **Next:** [Ed25519](../ed25519/)

--- a/blackjack/encrypted-ixs/src/lib.rs
+++ b/blackjack/encrypted-ixs/src/lib.rs
@@ -1,3 +1,8 @@
+//! Blackjack circuits: shuffle and deal an encrypted 52-card deck, apply player
+//! actions and dealer play against it, and resolve the winner. The deck and the
+//! dealer's hand stay encrypted to the MXE; the player learns only their own hand,
+//! the dealer's face-up card, and revealed bust/result flags. See README.md.
+
 use arcis::*;
 
 #[encrypted]
@@ -14,15 +19,17 @@ mod circuits {
     type Deck = Pack<[u8; 52]>;
     type Hand = Pack<[u8; 11]>;
 
+    /// Shuffles the deck and deals two cards each. The deck and dealer hand are
+    /// encrypted to the MXE; the player receives their hand and the dealer's face-up card.
     #[instruction]
     pub fn shuffle_and_deal_cards(
         client: Shared,
         client_again: Shared,
     ) -> (
-        Enc<Mxe, Deck>,    // 16 + 32 x 2
-        Enc<Mxe, Hand>,    // 16 + 32
-        Enc<Shared, Hand>, // 32 + 16 + 32
-        Enc<Shared, u8>,   // 32 + 16 + 32
+        Enc<Mxe, Deck>,
+        Enc<Mxe, Hand>,
+        Enc<Shared, Hand>,
+        Enc<Shared, u8>,
     ) {
         let mut initial_deck: [u8; 52] = INITIAL_DECK;
         ArcisRNG::shuffle(&mut initial_deck);
@@ -30,6 +37,7 @@ mod circuits {
         let deck_packed: Deck = Pack::new(initial_deck);
         let deck = Mxe::get().from_arcis(deck_packed);
 
+        // 53 marks an empty slot; only indices 0-51 count toward hand value.
         let mut dealer_cards = [53u8; 11];
         dealer_cards[0] = initial_deck[1];
         dealer_cards[1] = initial_deck[3];
@@ -50,6 +58,8 @@ mod circuits {
         )
     }
 
+    /// Draws the next card from the encrypted deck into the player's hand.
+    /// Reveals only whether the player busted.
     #[instruction]
     pub fn player_hit(
         deck_ctxt: Enc<Mxe, Deck>,
@@ -72,7 +82,7 @@ mod circuits {
         )
     }
 
-    // Returns true if the player has busted
+    /// Reveals only whether the player's final hand is a bust.
     #[instruction]
     pub fn player_stand(player_hand_ctxt: Enc<Shared, Hand>, player_hand_size: u8) -> bool {
         let player_hand = player_hand_ctxt.to_arcis().unpack();
@@ -80,7 +90,8 @@ mod circuits {
         (value > 21).reveal()
     }
 
-    // Returns true if the player has busted, if not, returns the new card
+    /// Same draw as `player_hit`; the program marks the player as stood afterward.
+    /// Reveals only whether the player busted.
     #[instruction]
     pub fn player_double_down(
         deck_ctxt: Enc<Mxe, Deck>,
@@ -103,7 +114,8 @@ mod circuits {
         )
     }
 
-    // Function for dealer to play (reveal hole card and follow rules)
+    /// Dealer draws from the encrypted deck until reaching 17. Returns the hand
+    /// re-encrypted to the MXE and to the player, and reveals only the final hand size.
     #[instruction]
     pub fn dealer_play(
         deck_ctxt: Enc<Mxe, Deck>,
@@ -132,17 +144,8 @@ mod circuits {
         )
     }
 
-    /// Calculates the blackjack value of a hand according to standard rules.
-    ///
-    /// Card values: Ace = 1 or 11 (whichever is better), Face cards = 10, Others = face value.
-    /// Aces are initially valued at 11, but automatically reduced to 1 if the hand would bust.
-    ///
-    /// # Arguments
-    /// * `hand` - Array of up to 11 cards (more than enough for blackjack)
-    /// * `hand_length` - Number of actual cards in the hand
-    ///
-    /// # Returns
-    /// The total value of the hand (1-21, or >21 if busted)
+    /// Standard blackjack hand value: aces count 11 then drop to 1 while the hand
+    /// would bust; face cards count 10. Slots beyond `hand_length` are ignored.
     fn calculate_hand_value(hand: &[u8; 11], hand_length: u8) -> u8 {
         let mut value: u8 = 0;
         let mut ace_count: u8 = 0;
@@ -174,18 +177,8 @@ mod circuits {
         value
     }
 
-    /// Determines the final winner of the blackjack game.
-    ///
-    /// Compares the final hand values according to blackjack rules and returns
-    /// a numeric result indicating the outcome. Both hands are evaluated for busts
-    /// and compared for the winner.
-    ///
-    /// # Returns
-    /// * 0 = Player busts (dealer wins)
-    /// * 1 = Dealer busts (player wins)
-    /// * 2 = Player wins (higher value, no bust)
-    /// * 3 = Dealer wins (higher value, no bust)
-    /// * 4 = Push/tie (same value, no bust)
+    /// Compares final hands and reveals only a result code: 0 player bust,
+    /// 1 dealer bust, 2 player wins, 3 dealer wins, 4 push.
     #[instruction]
     pub fn resolve_game(
         player_hand: Enc<Shared, Hand>,
@@ -196,21 +189,19 @@ mod circuits {
         let player_hand = player_hand.to_arcis().unpack();
         let dealer_hand = dealer_hand.to_arcis().unpack();
 
-        // Calculate final hand values
         let player_value = calculate_hand_value(&player_hand, player_hand_length);
         let dealer_value = calculate_hand_value(&dealer_hand, dealer_hand_length);
 
-        // Apply blackjack rules to determine winner
         let result = if player_value > 21 {
-            0 // Player busts - dealer wins automatically
+            0 // player bust
         } else if dealer_value > 21 {
-            1 // Dealer busts - player wins automatically
+            1 // dealer bust
         } else if player_value > dealer_value {
-            2 // Player has higher value without busting
+            2 // player wins
         } else if dealer_value > player_value {
-            3 // Dealer has higher value without busting
+            3 // dealer wins
         } else {
-            4 // Equal values - push (tie)
+            4 // push
         };
 
         result.reveal()

--- a/blackjack/programs/blackjack/src/lib.rs
+++ b/blackjack/programs/blackjack/src/lib.rs
@@ -1,3 +1,10 @@
+//! Single-player blackjack against an MPC dealer. Stateful: each `BlackjackGame` PDA
+//! stores the encrypted deck and hands, and every action feeds those ciphertexts back
+//! into circuits with `ArgBuilder` account references addressed by byte offset.
+//! Layout after the 8-byte discriminator: deck at offset 8 (2 x 32-byte ciphertexts,
+//! since `Pack<[u8; 52]>` packs 26 bytes per field element), player_hand at 72
+//! (32 bytes), dealer_hand at 104 (32 bytes). `GameState` gates instruction order.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 use arcium_client::idl::arcium::types::CallbackAccount;
@@ -15,8 +22,6 @@ declare_id!("62gnbWAVJ1FUA5umak7kjGu4t4THWw7Zo1AZo6q5Tgb8");
 pub mod blackjack {
     use super::*;
 
-    /// Initializes the computation definition for shuffling and dealing cards.
-    /// This sets up the MPC environment for the initial deck shuffle and card dealing operation.
     pub fn init_shuffle_and_deal_cards_comp_def(
         ctx: Context<InitShuffleAndDealCardsCompDef>,
     ) -> Result<()> {
@@ -24,16 +29,8 @@ pub mod blackjack {
         Ok(())
     }
 
-    /// Creates a new blackjack game session and initiates the deck shuffle.
-    ///
-    /// This function sets up a new game account with initial state and triggers the MPC computation
-    /// to shuffle a standard 52-card deck and deal the opening hands (2 cards each to player and dealer).
-    /// The actual shuffling and dealing happens confidentially within the Arcium network.
-    ///
-    /// # Arguments
-    /// * `game_id` - Unique identifier for this game session
-    /// * `client_pubkey` - Player's encryption public key for receiving encrypted cards
-    /// * `client_nonce` - Player's cryptographic nonce for encryption operations
+    /// Creates the `BlackjackGame` PDA and queues `shuffle_and_deal_cards`,
+    /// which shuffles the deck and deals the opening hands inside MPC.
     pub fn initialize_blackjack_game(
         ctx: Context<InitializeBlackjackGame>,
         computation_offset: u64,
@@ -42,7 +39,6 @@ pub mod blackjack {
         client_nonce: u128,
         client_again_nonce: u128,
     ) -> Result<()> {
-        // Initialize the blackjack game account
         let blackjack_game = &mut ctx.accounts.blackjack_game;
         blackjack_game.bump = ctx.bumps.blackjack_game;
         blackjack_game.game_id = game_id;
@@ -52,7 +48,8 @@ pub mod blackjack {
         blackjack_game.player_hand_size = 0;
         blackjack_game.dealer_hand_size = 0;
 
-        // Queue the shuffle and deal cards computation
+        // Argument order must match the circuit signature: one pubkey/nonce pair
+        // per `Shared` parameter of shuffle_and_deal_cards.
         let args = ArgBuilder::new()
             .x25519_pubkey(client_pubkey)
             .plaintext_u128(client_nonce)
@@ -60,6 +57,7 @@ pub mod blackjack {
             .plaintext_u128(client_again_nonce)
             .build();
 
+        // Persist the bump before queue_computation; the callback signs with this PDA.
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
 
         queue_computation(
@@ -81,11 +79,7 @@ pub mod blackjack {
         Ok(())
     }
 
-    /// Handles the result of the shuffle and deal cards MPC computation.
-    ///
-    /// This callback processes the shuffled deck and dealt cards from the MPC computation.
-    /// It updates the game state with the new deck, initial hands, and sets the game to PlayerTurn.
-    /// The player receives their encrypted hand while the dealer gets one face-up card visible to the player.
+    /// Stores the shuffled deck and opening hands, then moves the game to `PlayerTurn`.
     #[arcium_callback(encrypted_ix = "shuffle_and_deal_cards")]
     pub fn shuffle_and_deal_cards_callback(
         ctx: Context<ShuffleAndDealCardsCallback>,
@@ -127,23 +121,20 @@ pub mod blackjack {
 
         let dealer_face_up_card: [u8; 32] = o.3.ciphertexts[0];
 
-        // Update the blackjack game account
         let blackjack_game = &mut ctx.accounts.blackjack_game;
         blackjack_game.deck = deck;
         blackjack_game.deck_nonce = deck_nonce;
         blackjack_game.client_nonce = client_nonce;
         blackjack_game.dealer_nonce = dealer_nonce;
         blackjack_game.player_enc_pubkey = client_pubkey;
-        blackjack_game.game_state = GameState::PlayerTurn; // It is now the player's turn
+        blackjack_game.game_state = GameState::PlayerTurn;
 
         require!(
             dealer_client_pubkey == blackjack_game.player_enc_pubkey,
             ErrorCode::InvalidDealerClientPubkey
         );
 
-        // Initialize player hand with first two cards
         blackjack_game.player_hand = player_hand;
-        // Initialize dealer hand with face up card and face down card
         blackjack_game.dealer_hand = dealer_hand;
         blackjack_game.player_hand_size = 2;
         blackjack_game.dealer_hand_size = 2;
@@ -162,11 +153,7 @@ pub mod blackjack {
         Ok(())
     }
 
-    /// Allows the player to request an additional card (hit).
-    ///
-    /// This triggers an MPC computation that draws the next card from the shuffled deck
-    /// and adds it to the player's hand. The computation also checks if the player busts (exceeds 21)
-    /// and returns this information while keeping the actual card values encrypted.
+    /// Draws the next card into the player's hand inside MPC; only the bust flag is revealed.
     pub fn player_hit(
         ctx: Context<PlayerHit>,
         computation_offset: u64,
@@ -185,6 +172,8 @@ pub mod blackjack {
             ErrorCode::InvalidMove
         );
 
+        // Ciphertexts are read directly from the game account by byte offset
+        // (see module header); nonces must be the ones stored alongside them.
         let args = ArgBuilder::new()
             // Deck
             .plaintext_u128(ctx.accounts.blackjack_game.deck_nonce)
@@ -275,6 +264,7 @@ pub mod blackjack {
         Ok(())
     }
 
+    /// Draws one final card like `player_hit`, then the player automatically stands.
     pub fn player_double_down(
         ctx: Context<PlayerDoubleDown>,
         computation_offset: u64,
@@ -382,6 +372,7 @@ pub mod blackjack {
         Ok(())
     }
 
+    /// Ends the player's turn; the circuit reveals only whether the final hand busted.
     pub fn player_stand(
         ctx: Context<PlayerStand>,
         computation_offset: u64,
@@ -463,6 +454,8 @@ pub mod blackjack {
         Ok(())
     }
 
+    /// Runs the dealer's draw-to-17 inside MPC; `nonce` re-encrypts the final
+    /// dealer hand to the player.
     pub fn dealer_play(
         ctx: Context<DealerPlay>,
         computation_offset: u64,
@@ -558,6 +551,7 @@ pub mod blackjack {
         Ok(())
     }
 
+    /// Compares both hands inside MPC; only the result code is revealed.
     pub fn resolve_game(
         ctx: Context<ResolveGame>,
         computation_offset: u64,
@@ -1333,12 +1327,8 @@ pub struct InitResolveGameCompDef<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// Represents a single blackjack game session.
-///
-/// This account stores all the game state including encrypted hands, deck information,
-/// and game progress. The deck is stored as two 32-byte encrypted chunks (Pack<[u8; 52]>)
-/// that together represent all 52 cards in shuffled order. Hands are stored encrypted and only
-/// decryptable by their respective owners (player) or the MPC network (dealer).
+/// A single blackjack game session. Ciphertext fields are fed back into circuits by
+/// byte offset, so their order here must match the offsets in the module header.
 #[account]
 #[derive(InitSpace)]
 pub struct BlackjackGame {

--- a/blackjack/tests/blackjack.ts
+++ b/blackjack/tests/blackjack.ts
@@ -1,3 +1,12 @@
+/**
+ * Flow: init comp defs -> initializeBlackjackGame (shuffle_and_deal_cards) ->
+ * decrypt player hand + dealer face-up card -> hit/stand loop playing basic
+ * strategy -> dealerPlay -> resolveGame.
+ *
+ * Unique here: hands come back as Pack'd ciphertexts, so the client
+ * decrypts a single field element and shifts out 8-bit lanes (unpackHand)
+ * instead of using generated circuit types.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey, Keypair } from "@solana/web3.js";
@@ -26,7 +35,7 @@ import {
 import * as fs from "fs";
 import * as os from "os";
 import { expect } from "chai";
-// Helper function to calculate Blackjack hand value
+
 function calculateHandValue(cards: number[]): {
   value: number;
   isSoft: boolean;
@@ -36,28 +45,23 @@ function calculateHandValue(cards: number[]): {
   let isSoft = false;
 
   for (const cardIndex of cards) {
-    // Map card index (0-51) to value (Ace=11/1, K/Q/J=10, 2-10=face value)
     const rank = cardIndex % 13; // 0=Ace, 1=2, ..., 9=10, 10=J, 11=Q, 12=K
     if (rank === 0) {
-      // Ace
       aceCount++;
       value += 11;
     } else if (rank >= 10) {
-      // K, Q, J
       value += 10;
     } else {
-      // 2-10
       value += rank + 1;
     }
   }
 
-  // Adjust for Aces if value > 21
   while (value > 21 && aceCount > 0) {
     value -= 10;
     aceCount--;
   }
 
-  // Check if the hand is "soft" (contains an Ace counted as 11)
+  // A hand is "soft" while an Ace still counts as 11.
   isSoft = aceCount > 0 && value <= 21;
 
   return { value, isSoft };
@@ -77,7 +81,6 @@ function unpackHand(packed: bigint[], handSize: number): number[] {
 describe("Blackjack", () => {
   const owner = readKpJson(`${os.homedir()}/.config/solana/id.json`);
 
-  // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Blackjack as Program<Blackjack>;
   const provider = anchor.getProvider() as anchor.AnchorProvider;
@@ -213,8 +216,7 @@ describe("Blackjack", () => {
     let gameState = await program.account.blackjackGame.fetch(blackjackGamePDA);
     expect(gameState.gameState).to.deep.equal({ playerTurn: {} });
 
-    // Decrypt initial hands
-    // Convert anchor.BN to Uint8Array (16 bytes for u128) - manual conversion
+    // Nonces are u128s emitted as anchor.BN; the cipher needs 16 little-endian bytes.
     let currentClientNonce = Uint8Array.from(
       cardsShuffledAndDealtEvent.clientNonce.toArray("le", 16)
     );

--- a/coinflip/README.md
+++ b/coinflip/README.md
@@ -2,7 +2,8 @@
 
 The player encrypts a heads-or-tails guess, the MPC cluster flips a coin using
 randomness no individual node can predict or bias, and only the win/loss bit becomes
-public. The guess and the toss stay encrypted end to end.
+public. The guess and toss are never published directly, though the player can infer
+the toss from their guess and the public outcome.
 
 **Use this pattern when** no party (operator, player, or any single node) may
 predict or influence a random outcome: lotteries, random drops, fair matchmaking.
@@ -17,8 +18,8 @@ predict or influence a random outcome: lotteries, random drops, fair matchmaking
    its comparison against the guess; both operands remain secret shares throughout.
 4. `flip_callback` verifies the signed output and emits `FlipEvent`; nothing is stored.
 
-Anyone can see the win/loss bit; the guess and the toss are visible to no one, not
-even the nodes.
+Anyone can see the win/loss bit. The guess remains known only to the player, and no
+node sees either operand; the player can derive the toss from their guess and outcome.
 
 ## Concepts demonstrated
 
@@ -53,7 +54,8 @@ Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
 ## Limitations
 
-- Only the guess and the toss are private; the outcome is public to any observer.
+- The outcome is public. It does not reveal the guess to observers, but it lets the
+  player infer the toss because they already know their guess.
 - The result lives only in `FlipEvent`; nothing persists on chain, so other programs
   cannot consume the outcome. A production game would also need a wager and payout.
 

--- a/coinflip/README.md
+++ b/coinflip/README.md
@@ -1,91 +1,60 @@
-# Coinflip - Trustless Randomness
+# Coinflip — trustless randomness
 
-Flip a coin online and you have to trust someone. Trust the server not to rig the flip, or trust yourself not to inspect the code and game the system. There's no way to prove it's actually random.
+The player encrypts a heads-or-tails guess, the MPC cluster flips a coin using
+randomness no individual node can predict or bias, and only the win/loss bit becomes
+public. The guess and the toss stay encrypted end to end.
 
-This example shows how to generate verifiably random outcomes using distributed entropy generation.
+**Use this pattern when** no party (operator, player, or any single node) may
+predict or influence a random outcome: lotteries, random drops, fair matchmaking.
 
-## Why is randomness hard to trust online?
+## How it works
 
-Traditional random number generation has a fundamental trust problem: whoever generates the random number can potentially influence or predict it. Server-side RNG can be biased by operators, client-side generation can be manipulated, and pseudorandom algorithms may have predictable patterns. The requirement is generating randomness that remains unpredictable and unbiased even when participants don't trust each other.
+1. The client derives a shared secret with the MXE via x25519, encrypts the boolean
+   guess with `RescueCipher`, and calls `flip` with ciphertext, public key, and nonce.
+2. `flip` packs the arguments with `ArgBuilder` and queues the computation via
+   `queue_computation`, registering `flip_callback` for the result.
+3. The `flip` circuit draws a random boolean with `ArcisRNG::bool()` and reveals only
+   its comparison against the guess; both operands remain secret shares throughout.
+4. `flip_callback` verifies the signed output and emits `FlipEvent`; nothing is stored.
 
-## How It Works
+Anyone can see the win/loss bit; the guess and the toss are visible to no one, not
+even the nodes.
 
-The coinflip follows this flow:
+## Concepts demonstrated
 
-1. **Player commitment**: The player's choice (heads/tails) is encrypted and submitted to the network
-2. **Random generation**: Arcium nodes work together to generate a random boolean outcome
-3. **Encrypted comparison**: The system compares the encrypted choice against the encrypted random result
-4. **Result disclosure**: Only the win/loss outcome is revealed
+- MPC randomness: `ArcisRNG::bool()` in the `flip` circuit draws a toss no single node
+  can bias ([random number generation](https://docs.arcium.com/developers/arcis/primitives#random-number-generation)).
+- Selective reveal: `.reveal()` wraps only the equality check — exactly one bit of
+  the computation becomes public.
+- Stateless MXE program: no game accounts; the callback only emits an event.
 
-The comparison occurs on encrypted values throughout the computation.
-
-## Running the Example
+## Run
 
 ```bash
-# Install dependencies
-yarn install  # or npm install or pnpm install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite demonstrates the complete flow: player choice submission, secure random generation, encrypted comparison, and result verification.
+Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-The player's choice is encrypted as a boolean, allowing result verification without exposing the choice prematurely. Random generation uses Arcium's cryptographic primitives, where Arcium nodes contribute entropy that no single node can predict or control.
+- `encrypted-ixs/src/lib.rs` — note how the circuit reveals only the comparison,
+  never `toss` or the guess.
+- `programs/coinflip/src/lib.rs` — note how `flip_callback` calls `verify_output`
+  before trusting the result.
+- `tests/coinflip.ts` — note how the `FlipEvent` listener is registered before
+  queueing, so the one-shot result is not missed.
 
-## Implementation Details
+## Pitfalls
 
-### The Trustless Randomness Problem
+- `ArgBuilder` order must mirror the circuit signature: `Enc<Shared, UserChoice>` is
+  `x25519_pubkey`, `plaintext_u128` nonce, then ciphertext; a wrong order fails at
+  computation time, not at build time.
 
-**Conceptual Challenge**: In traditional online systems, randomness comes from somewhere - a server, a third-party service, your browser's `Math.random()`. Each source requires trusting that entity:
+## Limitations
 
-- **Server-generated**: Trust the operator doesn't rig outcomes
-- **Third-party service**: Trust the service provider is honest
-- **Client-side**: Trust the player doesn't inspect and manipulate
+- Only the guess and the toss are private; the outcome is public to any observer.
+- The result lives only in `FlipEvent`; nothing persists on chain, so other programs
+  cannot consume the outcome. A production game would also need a wager and payout.
 
-**The Question**: Can we generate randomness where NO single party can predict or bias the outcome?
-
-### The MPC Randomness Solution
-
-Arcium's `ArcisRNG` generates randomness through multi-party computation:
-
-```rust
-pub fn flip(input_ctxt: Enc<Shared, UserChoice>) -> bool {
-    let input = input_ctxt.to_arcis();
-    let toss = ArcisRNG::bool();  // MPC-generated randomness
-    (input.choice == toss).reveal()
-}
-```
-
-> See [Arcis Primitives](https://docs.arcium.com/developers/arcis/primitives) for all randomness and cryptographic operations.
-
-**How it works**:
-
-1. Arcium nodes each generate local random values
-2. Nodes combine their randomness using secure multi-party computation
-3. Final random value is deterministic given all inputs
-4. **No single node can predict the result** before all contribute
-5. **No subset of nodes can bias the outcome**: The MPC protocol guarantees unbiased randomness even with a dishonest majority—the outcome remains unpredictable as long as one node is honest
-
-### Stateless Design
-
-Unlike Voting or Blackjack, Coinflip has **no game state account**:
-
-- Receive encrypted player choice → Generate MPC random → Compare → Emit result
-- Each flip is independent
-- No persistent storage needed
-
-When randomness generation itself is the primary feature, stateless design is simplest.
-
-### When to Use This Pattern
-
-Use MPC randomness (`ArcisRNG`) when:
-
-- **No one should control outcome**: Lotteries, random drops, fair matchmaking
-- **Platform can't be trusted**: House games where operator could cheat
-- **Randomness is high-value**: Large prizes or critical game mechanics
+See also: [Callback type generation](https://docs.arcium.com/developers/program/callback-type-generation) · **Next:** [Rock Paper Scissors](../rock_paper_scissors/)

--- a/coinflip/encrypted-ixs/src/lib.rs
+++ b/coinflip/encrypted-ixs/src/lib.rs
@@ -1,35 +1,26 @@
+//! Coinflip circuit: draws an MPC random boolean and compares it against the
+//! player's encrypted guess. Only the win/loss bit is revealed; the guess and
+//! the toss stay secret. See README.md for the full flow.
+
 use arcis::*;
 
 #[encrypted]
 mod circuits {
     use arcis::*;
 
-    /// Represents the player's choice in the coin flip game.
+    /// The player's guess: true for heads, false for tails.
     pub struct UserChoice {
-        pub choice: bool, // Player's choice: true for heads, false for tails
+        pub choice: bool,
     }
 
-    /// Performs a confidential coin flip and compares it with the player's choice.
-    ///
-    /// This function generates a cryptographically secure random boolean value within
-    /// the MPC environment and compares it with the player's encrypted choice.
-    /// The comparison result (win/lose) is revealed while keeping both the player's
-    /// choice and the actual coin flip result confidential.
-    ///
-    /// # Arguments
-    /// * `input_ctxt` - Player's encrypted choice (heads or tails)
-    ///
-    /// # Returns
-    /// * `true` if the player's choice matches the coin flip (player wins)
-    /// * `false` if the player's choice doesn't match (player loses)
+    /// Flips a coin inside MPC and reveals only whether the player guessed right.
     #[instruction]
     pub fn flip(input_ctxt: Enc<Shared, UserChoice>) -> bool {
         let input = input_ctxt.to_arcis();
 
-        // Generate a cryptographically secure random boolean (the coin flip)
         let toss = ArcisRNG::bool();
 
-        // Compare player's choice with the coin flip result and reveal only the outcome
+        // Reveal only the comparison; the guess and the toss remain secret.
         (input.choice == toss).reveal()
     }
 }

--- a/coinflip/encrypted-ixs/src/lib.rs
+++ b/coinflip/encrypted-ixs/src/lib.rs
@@ -1,6 +1,6 @@
 //! Coinflip circuit: draws an MPC random boolean and compares it against the
-//! player's encrypted guess. Only the win/loss bit is revealed; the guess and
-//! the toss stay secret. See README.md for the full flow.
+//! player's encrypted guess. Only the win/loss bit is revealed directly; combined
+//! with their guess, it lets the player infer the toss. See README.md for the flow.
 
 use arcis::*;
 
@@ -20,7 +20,7 @@ mod circuits {
 
         let toss = ArcisRNG::bool();
 
-        // Reveal only the comparison; the guess and the toss remain secret.
+        // Reveal only the comparison; neither operand is revealed directly.
         (input.choice == toss).reveal()
     }
 }

--- a/coinflip/programs/coinflip/src/lib.rs
+++ b/coinflip/programs/coinflip/src/lib.rs
@@ -1,3 +1,8 @@
+//! Stateless coinflip program. `flip` queues an MPC computation with the
+//! player's encrypted guess; the cluster flips a coin, and `flip_callback`
+//! emits the win/loss result as a `FlipEvent`. No game state is stored on
+//! chain. Circuit: `encrypted-ixs/src/lib.rs`. Walkthrough: README.md.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 
@@ -9,23 +14,14 @@ declare_id!("3oizgCNBwGM9ceRk2sJ45cknkCMN5nSKRHaEWKESzHQj");
 pub mod coinflip {
     use super::*;
 
-    /// Initializes the computation definition for the coin flip operation.
-    /// This sets up the MPC environment for generating secure randomness and comparing it with the player's choice.
+    /// Registers the `flip` computation definition with the MXE.
     pub fn init_flip_comp_def(ctx: Context<InitFlipCompDef>) -> Result<()> {
         init_computation_def(ctx.accounts, None)?;
         Ok(())
     }
 
-    /// Initiates a coin flip game with the player's encrypted choice.
-    ///
-    /// The player submits their choice (heads or tails) in encrypted form along with their
-    /// public key and nonce. The MPC computation will generate a cryptographically secure
-    /// random boolean and compare it with the player's choice to determine if they won.
-    ///
-    /// # Arguments
-    /// * `user_choice` - Player's encrypted choice (true for heads, false for tails)
-    /// * `pub_key` - Player's public key for encryption operations
-    /// * `nonce` - Cryptographic nonce for the encryption
+    /// Queues the coin flip computation with the player's encrypted guess
+    /// (true = heads, false = tails). The result arrives via `flip_callback`.
     pub fn flip(
         ctx: Context<Flip>,
         computation_offset: u64,
@@ -33,12 +29,15 @@ pub mod coinflip {
         pub_key: [u8; 32],
         nonce: u128,
     ) -> Result<()> {
+        // Argument order must match the circuit signature: Enc<Shared, UserChoice>
+        // is supplied as pubkey, then nonce, then ciphertext.
         let args = ArgBuilder::new()
             .x25519_pubkey(pub_key)
             .plaintext_u128(nonce)
             .encrypted_u8(user_choice)
             .build();
 
+        // Persist the bump before queue_computation so the callback can sign.
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
 
         queue_computation(
@@ -58,11 +57,7 @@ pub mod coinflip {
         Ok(())
     }
 
-    /// Handles the result of the coin flip MPC computation.
-    ///
-    /// This callback receives the result of comparing the player's choice with the
-    /// randomly generated coin flip. The result is a boolean indicating whether
-    /// the player won (true) or lost (false).
+    /// Verifies the MPC output and emits the win/loss result as a `FlipEvent`.
     #[arcium_callback(encrypted_ix = "flip")]
     pub fn flip_callback(
         ctx: Context<FlipCallback>,
@@ -189,7 +184,7 @@ pub struct InitFlipCompDef<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// Event emitted when a coin flip game completes.
+/// Emitted when a coin flip completes; the only place the result is delivered.
 #[event]
 pub struct FlipEvent {
     /// Whether the player won the coin flip (true = won, false = lost)

--- a/coinflip/tests/coinflip.ts
+++ b/coinflip/tests/coinflip.ts
@@ -1,3 +1,11 @@
+/**
+ * Flow: init comp def -> x25519 shared secret with MXE -> encrypt
+ * guess (RescueCipher) -> queue `flip` -> await finalization -> read win/loss
+ * from `FlipEvent`.
+ *
+ * Unique here: the result is delivered only as an event, so the listener is
+ * registered before the computation is queued.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey } from "@solana/web3.js";
@@ -27,7 +35,6 @@ import * as fs from "fs";
 import * as os from "os";
 
 describe("Coinflip", () => {
-  // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Coinflip as Program<Coinflip>;
   const provider = anchor.getProvider();
@@ -73,6 +80,7 @@ describe("Coinflip", () => {
       initFlipSig
     );
 
+    // Shared secret with the MXE cluster; RescueCipher encrypts under it.
     const privateKey = x25519.utils.randomSecretKey();
     const publicKey = x25519.getPublicKey(privateKey);
     const sharedSecret = x25519.getSharedSecret(privateKey, mxePublicKey);

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -1,59 +1,66 @@
-# Ed25519 Signatures - Confidential Key Management
+# Ed25519 — distributed key management
 
-This example demonstrates Ed25519 signing and verification using distributed key management through multi-party computation. The private key is split across multiple nodes and never exists in a single location.
+An MXE signs messages with an Ed25519 key that exists only as secret shares across the cluster's
+nodes: MPC among the shares produces a standard signature without the key ever being assembled.
+A second circuit verifies a signature against an encrypted public key, hiding the checked identity.
 
-## How It Works
+**Use this pattern when** you need standard signatures (attestations, cross-chain messages)
+without any single party ever holding the key, or checks that hide whose key was verified.
 
-**Message Signing**: A message is sent to the Arcium network where MPC nodes collectively generate a valid Ed25519 signature using their key shares. The signature can be verified by anyone using the public key.
+## How it works
 
-**Signature Verification with Confidential Public Key**: The verifying key (public key) is provided in encrypted form, and the signature is verified within MPC. Only the verification result (valid/invalid) is revealed to a designated observer.
+1. `sign_message` queues a plaintext 5-byte message; inside MPC, `MXESigningKey::sign` signs
+   over the nodes' key shares and reveals the resulting `ArcisEd25519Signature`.
+2. `sign_message_callback` reassembles the 64-byte signature from the two halves (r, s) the
+   circuit outputs and emits `SignMessageEvent`, verifiable by anyone against the MXE's key.
+3. For blind verification, the client encrypts a packed key (`Enc<Shared, Pack<VerifyingKey>>`)
+   under a one-time x25519 key and calls `verify_signature` with plaintext message and signature.
+4. The circuit checks the signature inside MPC and encrypts the boolean verdict for the
+   `observer`; `verify_signature_callback` emits it in `VerifySignatureEvent`.
 
-## Running the Example
+Signed messages and signatures are public by design; in verification only the verifying key
+stays hidden, and only the observer can read the verdict.
+
+## Concepts demonstrated
+
+- Distributed signing with [`MXESigningKey`](https://docs.arcium.com/developers/arcis/primitives#mxe-cluster-signing):
+  the key already lives inside the MXE, and the signature is deliberately revealed — it is only
+  useful when public.
+- [Data packing](https://docs.arcium.com/developers/arcis/primitives#data-packing):
+  `Pack<VerifyingKey>` fits the 32-byte key into two field elements, hence exactly two
+  `encrypted_u128` ciphertexts.
+- Mixed plaintext and encrypted arguments in one `ArgBuilder` chain, including the dedicated
+  `arcis_ed25519_signature` argument type.
+
+## Run
 
 ```bash
-# Install dependencies
-yarn install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite demonstrates both signing and verification flows with the MPC-managed key.
+Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-### MPC Signing
+- `encrypted-ixs/src/lib.rs` — note how `sign_message` takes no encrypted inputs at all, yet
+  its output depends on a secret no one holds.
+- `programs/ed_25519/src/lib.rs` — note how `verify_signature` assembles arguments in exactly
+  the order the circuit signature dictates.
+- `tests/ed_25519.ts` — note how `createPacker` builds the `VerifyingKey` packer by hand and
+  how the test randomly corrupts inputs to exercise the invalid path.
 
-Arcium's `MXESigningKey` enables signing through distributed key shares:
+## Pitfalls
 
-```rust
-pub fn sign_message(message: [u8; 5]) -> ArcisEd25519Signature {
-    let signature = MXESigningKey::sign(&message);
-    signature.reveal()
-}
-```
+- `ArgBuilder` order must mirror the circuit signature: the encrypted key param expands to
+  `x25519_pubkey` + nonce + two `encrypted_u128` ciphertexts, `observer: Shared` to pubkey + nonce last.
+- The client packer's field name must match the Arcis struct field (`public_key_encoded`)
+  exactly; a mismatch corrupts data silently.
+- Results arrive only via events; this program stores nothing on chain.
 
-Each MPC node holds a share of the private key and executes a distributed signing protocol to produce a standard Ed25519 signature without reconstructing the complete key.
+## Limitations
 
-> See [Arcis Primitives](https://docs.arcium.com/developers/arcis/primitives) for the full cryptographic API.
+- Messages are fixed at 5 bytes by the circuit signatures; other lengths need their own circuits.
+- `verify_signature` hides only the key and the verdict; the message and signature are public.
+- One signing key per MXE — no rotation, no per-user keys; every caller signs as the same identity.
 
-### Confidential Public Key Verification
-
-```rust
-pub fn verify_signature(
-    verifying_key_enc: Enc<Shared, Pack<VerifyingKey>>,
-    message: [u8; 5],
-    signature: [u8; 64],
-    observer: Shared,
-) -> Enc<Shared, bool> {
-    let verifying_key = verifying_key_enc.to_arcis().unpack();
-    let signature = ArcisEd25519Signature::from_bytes(signature);
-    let is_valid = verifying_key.verify(&message, &signature);
-    observer.from_arcis(is_valid)
-}
-```
-
-In some scenarios, revealing which public key is being verified could leak sensitive information (identity, organizational affiliations). This pattern enables verification without public key disclosure.
+See also: [Arcis cryptographic operations](https://docs.arcium.com/developers/arcis/primitives#cryptographic-operations)

--- a/ed25519/encrypted-ixs/src/lib.rs
+++ b/ed25519/encrypted-ixs/src/lib.rs
@@ -1,15 +1,23 @@
+//! Ed25519 circuits: `sign_message` signs with the MXE's share-split key (the
+//! private key never exists in one place), and `verify_signature` checks a
+//! signature against an encrypted verifying key. See README.md for the flow.
+
 use arcis::*;
 
 #[encrypted]
 mod circuits {
     use arcis::*;
 
+    /// Signs the message with the MXE's distributed Ed25519 key and reveals the
+    /// signature, which is standard and publicly verifiable.
     #[instruction]
     pub fn sign_message(message: [u8; 5]) -> ArcisEd25519Signature {
         let signature = MXESigningKey::sign(&message);
         signature.reveal()
     }
 
+    /// Verifies the signature against an encrypted verifying key; only the
+    /// observer can decrypt the boolean verdict. Message and signature are public.
     #[instruction]
     pub fn verify_signature(
         verifying_key_enc: Enc<Shared, Pack<VerifyingKey>>,

--- a/ed25519/programs/ed_25519/src/lib.rs
+++ b/ed25519/programs/ed_25519/src/lib.rs
@@ -1,3 +1,8 @@
+//! Stateless program for MPC Ed25519: `sign_message` produces a signature from
+//! the MXE's share-split key, `verify_signature` checks a signature against an
+//! encrypted verifying key. Results are delivered via events (`SignMessageEvent`,
+//! `VerifySignatureEvent`); no application state is stored on chain. See README.md.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 
@@ -10,29 +15,20 @@ declare_id!("BVDLKuPHre5sThUJVCG5Get4nEeBvki4hy3ZxFdpGu2p");
 pub mod ed_25519 {
     use super::*;
 
-    /// Initializes the computation definition for Ed25519 message signing.
-    /// This sets up the MPC environment for performing distributed key signing operations.
+    /// Initializes the computation definition for the `sign_message` circuit.
     pub fn init_sign_message_comp_def(ctx: Context<InitSignMessageCompDef>) -> Result<()> {
         init_computation_def(ctx.accounts, None)?;
         Ok(())
     }
 
-    /// Signs a message using the MXE's distributed Ed25519 private key.
-    ///
-    /// The message is signed within the MPC environment using the Arcium network's
-    /// collective signing key. The private key never exists in a single location,
-    /// yet a valid Ed25519 signature is produced through multi-party computation.
-    ///
-    /// # Arguments
-    /// * `message` - The 5-byte message to be signed
-    ///
-    /// # Returns
-    /// Returns the 64-byte Ed25519 signature via the SignMessageEvent
+    /// Queues MPC signing of `message` with the MXE's distributed Ed25519 key.
+    /// The 64-byte signature is emitted via `SignMessageEvent`.
     pub fn sign_message(
         ctx: Context<SignMessage>,
         computation_offset: u64,
         message: [u8; 5],
     ) -> Result<()> {
+        // The Arcium signer PDA bump must be persisted before queue_computation.
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
         let mut builder = ArgBuilder::new();
         for byte in message {
@@ -54,10 +50,8 @@ pub mod ed_25519 {
         Ok(())
     }
 
-    /// Handles the result of the MPC signing computation.
-    ///
-    /// This callback receives the Ed25519 signature components (r and s) from the
-    /// completed MPC computation and emits them as a standard 64-byte signature.
+    /// Reassembles the signature from the two 32-byte halves (r, s) the circuit
+    /// outputs and emits it as a standard 64-byte Ed25519 signature.
     #[arcium_callback(encrypted_ix = "sign_message")]
     pub fn sign_message_callback(
         ctx: Context<SignMessageCallback>,
@@ -86,28 +80,14 @@ pub mod ed_25519 {
         Ok(())
     }
 
-    /// Initializes the computation definition for Ed25519 signature verification.
-    /// This sets up the MPC environment for verifying signatures against encrypted public keys.
+    /// Initializes the computation definition for the `verify_signature` circuit.
     pub fn init_verify_signature_comp_def(ctx: Context<InitVerifySignatureCompDef>) -> Result<()> {
         init_computation_def(ctx.accounts, None)?;
         Ok(())
     }
 
-    /// Verifies an Ed25519 signature against an encrypted verifying key.
-    ///
-    /// This function allows signature verification where the public key remains encrypted
-    /// throughout the verification process. The verification happens within the MPC environment,
-    /// and only the boolean result (valid/invalid) is revealed.
-    ///
-    /// # Arguments
-    /// * `verifying_key_enc_lo` - Lower 128 bits of the encrypted packed verifying key
-    /// * `verifying_key_enc_hi` - Upper 128 bits of the encrypted packed verifying key
-    /// * `message` - The 5-byte message that was signed
-    /// * `signature` - The 64-byte Ed25519 signature to verify
-    /// * `observer_pub_key` - Public key for encrypting the verification result
-    ///
-    /// # Returns
-    /// Returns encrypted verification result via VerifySignatureEvent
+    /// Queues MPC verification of `signature` against an encrypted verifying key.
+    /// The encrypted boolean verdict is emitted via `VerifySignatureEvent`.
     pub fn verify_signature(
         ctx: Context<VerifySignature>,
         computation_offset: u64,
@@ -121,6 +101,9 @@ pub mod ed_25519 {
         observer_nonce: u128,
     ) -> Result<()> {
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
+        // Argument order must match the circuit signature: Enc<Shared, Pack<VerifyingKey>>
+        // expands to pubkey + nonce + two ciphertexts (a packed 32-byte key spans two
+        // field elements), and the trailing `observer: Shared` to pubkey + nonce.
         let mut builder = ArgBuilder::new()
             .x25519_pubkey(one_time_pub_key)
             .plaintext_u128(one_time_nonce)
@@ -150,10 +133,7 @@ pub mod ed_25519 {
         Ok(())
     }
 
-    /// Handles the result of the MPC signature verification computation.
-    ///
-    /// This callback receives the encrypted verification result and emits it for the observer
-    /// to decrypt. The verification outcome remains encrypted until the observer decrypts it.
+    /// Emits the encrypted verification verdict for the observer to decrypt.
     #[arcium_callback(encrypted_ix = "verify_signature")]
     pub fn verify_signature_callback(
         ctx: Context<VerifySignatureCallback>,

--- a/ed25519/tests/ed_25519.ts
+++ b/ed25519/tests/ed_25519.ts
@@ -5,8 +5,8 @@
  * -> observer decrypts the verdict.
  *
  * Unique here: the VerifyingKey packer is built by hand with createPacker, and
- * the test randomly corrupts message, key, or signature so the encrypted
- * verdict exercises both the valid and invalid paths.
+ * each run randomly chooses a valid case or corrupts the message, key, or
+ * signature for an invalid case.
  */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";

--- a/ed25519/tests/ed_25519.ts
+++ b/ed25519/tests/ed_25519.ts
@@ -1,3 +1,13 @@
+/**
+ * Flow: init comp defs -> sign_message (plaintext message) -> SignMessageEvent
+ * -> verify the MPC signature locally against the MXE verifying key -> encrypt
+ * a locally generated verifying key -> verify_signature -> VerifySignatureEvent
+ * -> observer decrypts the verdict.
+ *
+ * Unique here: the VerifyingKey packer is built by hand with createPacker, and
+ * the test randomly corrupts message, key, or signature so the encrypted
+ * verdict exercises both the valid and invalid paths.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey } from "@solana/web3.js";
@@ -42,7 +52,6 @@ const verifyingKeyPacker = createPacker<
 );
 
 describe("Ed25519", () => {
-  // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Ed25519 as Program<Ed25519>;
   const provider = anchor.getProvider();
@@ -178,7 +187,6 @@ describe("Ed25519", () => {
       }
     }
 
-    // pack the verifying key
     const verifyingKeyPacked = verifyingKeyPacker.pack({
       public_key_encoded: Array.from(verifyingKey),
     });

--- a/rock_paper_scissors/README.md
+++ b/rock_paper_scissors/README.md
@@ -1,40 +1,11 @@
-# Rock Paper Scissors - Encrypted Moves
+# Rock Paper Scissors
 
-Rock Paper Scissors only works if neither player can see the other's move before submitting their own. Online, moves are submitted asynchronously - Player 1 submits first, Player 2 submits hours or days later. How do you prevent Player 2 from seeing Player 1's encrypted move before making their choice?
+Two variants of the same game, differing in who the opponent is. In
+[Player vs Player](./against-player/), both players submit client-encrypted moves
+into MXE-owned game state, so neither can see the other's choice before committing;
+only the outcome is revealed. In [Player vs House](./against-house/), the opponent is
+the MPC cluster itself: the house move comes from in-circuit randomness, making it
+provably fair — no one, including the house, knows it before the player commits.
 
-This example demonstrates how encrypted moves enable fair asynchronous gameplay where neither player can see the other's choice, even when both moves are stored on a public blockchain.
-
-## Why can't you hide encrypted moves on a public blockchain?
-
-Physical Rock Paper Scissors works because moves are revealed simultaneously. Digital games are asynchronous: Player 1 submits their encrypted move on-chain, then Player 2 submits hours or days later. The challenge is preventing Player 2 from learning Player 1's move before submitting their own.
-
-Traditional approaches fail:
-
-- **Unencrypted storage**: Player 2 sees Player 1's move immediately
-- **Simple hashing (commit-reveal)**: With only 3 moves, Player 2 can brute-force all possible hashes
-- **Trusted servers**: Requires trusting a third party not to leak moves
-- **Time windows**: Don't solve the information hiding problem
-
-The solution: Player 1's move is **encrypted and immutable** (can't be changed, but hidden from Player 2), even when stored on a public blockchain.
-
-## How Encrypted Asynchronous Gameplay Works
-
-1. **Player 1 submits encrypted move**: Encrypted move submitted and stored on-chain
-2. **Asynchronous delay**: Player 2 can submit hours or days later
-3. **Player 2 submits encrypted move**: Submits encrypted move without seeing Player 1's choice
-4. **Encrypted comparison**: Moves compared without anyone being able to see them
-5. **Result revelation**: Only game outcome (win/loss/tie) revealed
-
-Player 1's move is **encrypted and immutable** (stored on-chain, can't be changed) but **hidden** (Player 2 can't decrypt it). Neither player gains information advantage, regardless of submission timing.
-
-## Variants
-
-Two implementations demonstrate different encrypted gameplay scenarios:
-
-### [Player vs Player](./against-player/)
-
-Two players submit encrypted moves. Neither party can access the opponent's choice until both encrypted moves are submitted.
-
-### [Player vs House](./against-house/)
-
-Player competes against an on-chain algorithm. The system cannot access the player's move before generating its response, ensuring provable fairness.
+- [Player vs Player](./against-player/) — asynchronous hidden moves from two encrypted submissions
+- [Player vs House](./against-house/) — provably fair RNG opponent

--- a/rock_paper_scissors/against-house/README.md
+++ b/rock_paper_scissors/against-house/README.md
@@ -3,7 +3,8 @@
 Rock-paper-scissors against a house whose move is drawn inside the MPC computation
 itself. The player's move is encrypted client-side, the house move is sampled from
 cluster randomness, and only a result code becomes public — neither move is ever
-visible to the operator, observers, or any individual node.
+published directly or visible to any individual node. The player can infer the house
+move afterward from their own move and the result.
 
 **Use this pattern when** a secret user input must be judged against randomness no
 party can predict or bias: casino-style games, random rewards on a private choice.
@@ -21,8 +22,8 @@ party can predict or bias: casino-style games, random rewards on a private choic
 4. `play_rps_callback` verifies the signed output and emits `PlayRpsEvent`; no game
    state is written.
 
-Anyone watching the chain sees the outcome; the program, observers, and individual
-nodes see neither the player's move nor the house's.
+Anyone watching the chain sees the outcome but cannot derive either move without
+knowing one of them. The player knows their move and can therefore derive the house's.
 
 ## Concepts demonstrated
 
@@ -61,6 +62,8 @@ Setup and troubleshooting: [repo README](../../README.md#running-an-example).
 ## Limitations
 
 - The outcome is public to every observer, not just the player.
+- The player can infer the house move from their own move and the outcome; it is
+  hidden before commitment, not after resolution.
 - If all 16 sampling rounds reject (probability 4^-16), `house_move` silently stays
   `0` and the house plays rock — negligible, but a production version should handle
   that case explicitly.

--- a/rock_paper_scissors/against-house/README.md
+++ b/rock_paper_scissors/against-house/README.md
@@ -1,47 +1,70 @@
-# Rock Paper Scissors vs House - Fair Gaming
+# Rock Paper Scissors vs House — hidden move, unbiased opponent
 
-Player-versus-house games require trust that the house algorithm operates fairly. In traditional implementations, the house can observe player moves before generating responses, or use biased random number generation to favor house outcomes.
+Rock-paper-scissors against a house whose move is drawn inside the MPC computation
+itself. The player's move is encrypted client-side, the house move is sampled from
+cluster randomness, and only a result code becomes public — neither move is ever
+visible to the operator, observers, or any individual node.
 
-This example demonstrates fair gaming where the house cannot access player moves before generating its response, and randomness generation is cryptographically secure.
+**Use this pattern when** a secret user input must be judged against randomness no
+party can predict or bias: casino-style games, random rewards on a private choice.
 
-## Why can't you trust the house?
+## How it works
 
-Traditional house games have multiple trust problems: the house can see player moves before responding, bias the random number generator, or modify game behavior without transparency. Every layer requires trusting the operator not to cheat, creating information asymmetry that favors the house.
+1. The client derives a shared secret with the MXE via x25519, encrypts the move
+   (`0` rock, `1` paper, `2` scissors) with `RescueCipher`, and calls `play_rps`,
+   which packs the arguments with `ArgBuilder` and queues the computation.
+2. The `play_rps` circuit receives the move as `Enc<Shared, PlayerMove>` and draws
+   the house move inside MPC: 16 rounds of rejection sampling over two
+   `ArcisRNG::bool()` bits, discarding value 3 so all three moves are equally likely.
+3. The circuit compares the moves and reveals only a result code: `0` tie, `1`
+   player wins, `2` house wins, `3` invalid move.
+4. `play_rps_callback` verifies the signed output and emits `PlayRpsEvent`; no game
+   state is written.
 
-## How Provably Fair Gaming Works
+Anyone watching the chain sees the outcome; the program, observers, and individual
+nodes see neither the player's move nor the house's.
 
-The protocol ensures fairness through cryptographic isolation:
+## Concepts demonstrated
 
-1. **Player encrypted submission**: The player's move is encrypted and submitted to the blockchain
-2. **Random house move**: Arcium nodes generate a random house move using cryptographic randomness
-3. **Encrypted comparison**: Both moves are compared in encrypted form
-4. **Result disclosure**: Only the game outcome (win/loss/tie) is revealed
+- Client secret meets cluster randomness: the `play_rps` circuit combines a
+  client-encrypted input with `ArcisRNG` output in one computation, so neither side
+  can react to the other.
+- Rejection sampling under circuit constraints: the loop runs a fixed 16 iterations
+  and latches the first valid candidate with a `selected` flag, because circuits
+  cannot `break` or return early
+  ([Arcis language constraints](https://docs.arcium.com/developers/limitations#arcis-language-constraints)).
 
-Random number generation uses cryptographic primitives that no single party can predict or bias.
-
-## Running the Example
+## Run
 
 ```bash
-# Install dependencies
-yarn install  # or npm install or pnpm install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite demonstrates the complete protocol: player move encryption, house random response generation, encrypted comparison, and outcome verification.
+Setup and troubleshooting: [repo README](../../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-The player's move is encrypted on the client and stored on-chain as a ciphertext. The house move is generated using Arcium's cryptographic randomness (similar to Coinflip), where Arcium nodes contribute entropy that no single node can predict or control.
+- `encrypted-ixs/src/lib.rs` — note how uniformity comes from discarding candidate
+  value 3 rather than taking a modulo, which would make rock twice as likely.
+- `programs/rock_paper_scissors_against_rng/src/lib.rs` — note how `ArgBuilder`
+  supplies `Enc<Shared, PlayerMove>` as pubkey, nonce, then ciphertext, exactly the
+  order the circuit expects.
+- `tests/rock_paper_scissors_against_rng.ts` — note how the client never decrypts
+  anything: the outcome arrives as plaintext in `PlayRpsEvent`.
 
-Both moves are compared inside MPC on encrypted values.
+## Pitfalls
 
-Key properties:
+- Move encoding is `0`/`1`/`2`. An out-of-range value cannot be rejected on-chain
+  (it is ciphertext there) and is not an error: the game completes and publicly
+  reveals result `3`, telling every observer the move was invalid.
 
-- **Cryptographic randomness**: Arcium nodes contribute entropy; no single node or subset can predict or bias the outcome
-- **Fair comparison**: Both moves processed in encrypted form throughout game resolution
-- **Integrity**: The MPC protocol ensures correct game resolution even with a dishonest majority—neither the house nor the player can manipulate the outcome as long as at least one node is honest
+## Limitations
+
+- The outcome is public to every observer, not just the player.
+- If all 16 sampling rounds reject (probability 4^-16), `house_move` silently stays
+  `0` and the house plays rock — negligible, but a production version should handle
+  that case explicitly.
+- Each call is an independent round: no wager, no score, no persistent state.
+
+See also: [Random number generation](https://docs.arcium.com/developers/arcis/primitives#random-number-generation) ·
+**Next:** [Voting](../../voting/)

--- a/rock_paper_scissors/against-house/encrypted-ixs/src/lib.rs
+++ b/rock_paper_scissors/against-house/encrypted-ixs/src/lib.rs
@@ -1,14 +1,20 @@
+//! Rock-paper-scissors circuit against a house move drawn inside MPC. The
+//! player's move stays encrypted; the house move comes from `ArcisRNG` via
+//! rejection sampling. Only the result code is revealed. See README.md.
+
 use arcis::*;
 
 #[encrypted]
 mod circuits {
     use arcis::*;
 
-    // Consider 0 - Rock, 1 - Paper, 2 - Scissors
+    /// The player's move: 0 = rock, 1 = paper, 2 = scissors.
     pub struct PlayerMove {
         player_move: u8,
     }
 
+    /// Draws a uniform random house move and reveals only the result code:
+    /// 0 = tie, 1 = player wins, 2 = house wins, 3 = invalid move.
     #[instruction]
     pub fn play_rps(player_move_ctxt: Enc<Shared, PlayerMove>) -> u8 {
         let player_move = player_move_ctxt.to_arcis();
@@ -16,6 +22,10 @@ mod circuits {
         let mut house_move: u8 = 0;
         let mut selected = false;
 
+        // Two random bits give a candidate in 0..=3; 3 is rejected so the
+        // three moves stay uniform (a modulo would bias rock to 50%). Circuits
+        // cannot break, so all 16 rounds run and `selected` latches the first
+        // accepted candidate.
         for _ in 0..16 {
             let b0 = ArcisRNG::bool();
             let b1 = ArcisRNG::bool();
@@ -39,7 +49,6 @@ mod circuits {
             selected = selected | candidate_valid;
         }
 
-        // 0 - tie, 1 - player wins, 2 - house wins, 3 - invalid move
         let result = if player_move.player_move > 2 {
             3
         } else if player_move.player_move == house_move {

--- a/rock_paper_scissors/against-house/programs/rock_paper_scissors_against_rng/src/lib.rs
+++ b/rock_paper_scissors/against-house/programs/rock_paper_scissors_against_rng/src/lib.rs
@@ -1,3 +1,9 @@
+//! Stateless rock-paper-scissors program with an MPC-generated house move.
+//! `play_rps` queues a computation with the player's encrypted move; the
+//! cluster draws the house move inside MPC and `play_rps_callback` emits the
+//! outcome as a `PlayRpsEvent`. No game state is stored on chain.
+//! Circuit: `encrypted-ixs/src/lib.rs`. Walkthrough: README.md.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 
@@ -9,11 +15,15 @@ declare_id!("CsfnLykGNvdHgAT58B75MKCz3yX4FDhwRsYFKq9wtmyN");
 pub mod rock_paper_scissors_against_rng {
     use super::*;
 
+    /// Registers the `play_rps` computation definition with the MXE.
     pub fn init_play_rps_comp_def(ctx: Context<InitPlayRpsCompDef>) -> Result<()> {
         init_computation_def(ctx.accounts, None)?;
         Ok(())
     }
 
+    /// Queues the game computation with the player's encrypted move
+    /// (0 = rock, 1 = paper, 2 = scissors). The result arrives via
+    /// `play_rps_callback`.
     pub fn play_rps(
         ctx: Context<PlayRps>,
         computation_offset: u64,
@@ -21,12 +31,15 @@ pub mod rock_paper_scissors_against_rng {
         pub_key: [u8; 32],
         nonce: u128,
     ) -> Result<()> {
+        // Argument order must match the circuit signature: Enc<Shared, PlayerMove>
+        // is supplied as pubkey, then nonce, then ciphertext.
         let args = ArgBuilder::new()
             .x25519_pubkey(pub_key)
             .plaintext_u128(nonce)
             .encrypted_u8(player_move)
             .build();
 
+        // Persist the bump before queue_computation so the callback can sign.
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
 
         queue_computation(
@@ -45,6 +58,7 @@ pub mod rock_paper_scissors_against_rng {
         Ok(())
     }
 
+    /// Verifies the MPC output and emits the game result as a `PlayRpsEvent`.
     #[arcium_callback(encrypted_ix = "play_rps")]
     pub fn play_rps_callback(
         ctx: Context<PlayRpsCallback>,

--- a/rock_paper_scissors/against-house/tests/rock_paper_scissors_against_rng.ts
+++ b/rock_paper_scissors/against-house/tests/rock_paper_scissors_against_rng.ts
@@ -1,3 +1,11 @@
+/**
+ * Flow: init comp def -> x25519 shared secret with MXE ->
+ * encrypt move (RescueCipher) -> queue `play_rps` -> await finalization ->
+ * read outcome from `PlayRpsEvent`.
+ *
+ * Unique here: the opponent is the MXE itself, so the client encrypts its
+ * input but never decrypts anything; the outcome arrives as a plain string.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey } from "@solana/web3.js";
@@ -78,7 +86,7 @@ describe("RockPaperScissorsAgainstRng", () => {
     const sharedSecret = x25519.getSharedSecret(privateKey, mxePublicKey);
     const cipher = new RescueCipher(sharedSecret);
 
-    const playerMove = BigInt(2); // 1 = rock, 2 = paper, 3 = scissors
+    const playerMove = BigInt(2); // 0 = rock, 1 = paper, 2 = scissors
     const plaintext = [playerMove];
 
     const nonce = randomBytes(16);

--- a/rock_paper_scissors/against-player/README.md
+++ b/rock_paper_scissors/against-player/README.md
@@ -1,111 +1,48 @@
-# Rock Paper Scissors - Player vs Player
+# Rock Paper Scissors vs Player — asynchronous hidden moves
 
-Player-versus-player asynchronous games require encrypted moves to prevent information advantages. Without cryptographic enforcement, players may observe opponent moves before finalizing their own, or modify submitted moves retroactively.
+Two players submit rock paper scissors moves at different times, each encrypted client-side and merged into MXE-owned game state that no individual party can decrypt. Neither player, the program, nor any single node ever sees a move; only the final outcome is revealed.
 
-This example demonstrates a player-versus-player protocol where both players submit encrypted moves asynchronously - neither can see the other's choice until both are submitted.
+**Use this pattern when** multiple parties submit hidden inputs asynchronously and only the result of comparing them should become public: sealed matches, blind negotiations, simultaneous-commitment games.
 
-## Why do public blockchains break asynchronous gameplay?
+## How it works
 
-Blockchains make everything public - which breaks games where information needs to stay hidden. Public blockchain state allows participants to observe transaction data before submitting their own moves, creating information advantages.
+1. `init_game` creates the `RPSGame` PDA with both players' public keys and queues the `init_game` circuit, which returns `Enc<Mxe, GameMoves>` with both move slots set to the sentinel `3` (valid moves are 0-2). The callback stores the two ciphertexts and the nonce in `RPSGame`.
+2. Each player encrypts a `PlayersMove` (slot index plus move) client-side and calls `player_move`. The program checks the signer is `player_a` or `player_b`, then passes the client-encrypted input and the ciphertexts stored in `RPSGame` into the `player_move` circuit.
+3. Inside MPC, the circuit writes the move into its slot only if the slot is still empty and the move is valid, then returns re-encrypted state; the callback overwrites `RPSGame` with the new ciphertexts and nonce.
+4. Once both slots are filled, anyone calls `compare_moves`. The circuit reveals a single `u8` outcome and the callback emits it as a `CompareMovesEvent` ("Tie", "Player A Wins", "Player B Wins", or "Invalid Move" if a slot was still empty).
 
-Traditional approaches have limitations: unencrypted storage makes moves visible to all participants immediately, decryption requires someone to view moves sequentially, and trusted referees who decrypt moves can potentially favor specific players.
+Moves stay MXE-owned end to end: each player knows only their own move, and the public learns only the outcome.
 
-The requirement is encrypted asynchronous submission where each player finalizes their choice before learning their opponent's move.
+## Concepts demonstrated
 
-## How Encrypted Asynchronous Gameplay Works
+- Client-encrypted input merged into MXE-owned state: `player_move` takes `Enc<Shared, PlayersMove>` alongside `Enc<Mxe, GameMoves>`, the same shape as the order book in [Input/output](https://docs.arcium.com/developers/arcis/input-output).
+- Passing stored ciphertexts back into MPC: `ArgBuilder`'s `account` method references the `RPSGame` account so the circuit computes over previously stored encrypted state ([Invoking computations](https://docs.arcium.com/developers/program)).
+- Sentinel-guarded writes: "has this player already moved" is decided inside the circuit by comparing against the sentinel, so submission status never leaks.
 
-The protocol enforces fairness through encrypted move submission and secure comparison:
-
-1. **Player 1 encrypted submission**: First player's move is encrypted and recorded on-chain
-2. **Player 2 encrypted submission**: Second player's move is encrypted and recorded on-chain
-3. **Verification**: System confirms both encrypted moves are submitted
-4. **Encrypted comparison**: Arcium nodes jointly compute the outcome
-5. **Result disclosure**: Only the game outcome (player 1 wins/player 2 wins/tie) is revealed
-
-The comparison occurs on encrypted values throughout. Only the final game outcome is revealed.
-
-## Running the Example
+## Run
 
 ```bash
-# Install dependencies
-yarn install  # or npm install or pnpm install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite simulates two-player gameplay with encrypted move submissions, demonstrating the complete protocol from move submission through outcome determination.
+Setup and troubleshooting: [repo README](../../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-Both player moves are encrypted and submitted on-chain. The game outcome is computed using Arcium's confidential instructions, which process encrypted moves without decryption.
+- `encrypted-ixs/src/lib.rs` — note how `player_move` validates slot and move entirely inside MPC and returns the state unchanged when the guard fails.
+- `programs/rock_paper_scissors/src/lib.rs` — note how `player_move` orders its `ArgBuilder` arguments: the shared input's pubkey, nonce, and ciphertexts before the MXE state's nonce and account slice.
+- `tests/rock_paper_scissors.ts` — note how each player derives their own x25519 shared secret with the MXE, and how every move awaits finalization before the next is queued.
 
-Key properties:
-- **Asynchronous encrypted commitment**: Both moves locked in before comparison, despite asynchronous submission
-- **Minimal revelation**: Only the game result is disclosed, not individual moves
-- **Integrity**: The MPC protocol ensures correct game resolution even with a dishonest majority—neither player can manipulate the outcome as long as one node is honest
+## Pitfalls
 
-## Implementation Details
+- `NotAuthorized`: `player_move` requires the signer to be the `player_a` or `player_b` recorded at `init_game`; signing with any other keypair fails on-chain.
+- `ArgBuilder` order must mirror the circuit signature: for `Enc<Shared, PlayersMove>`, pubkey then nonce then ciphertexts in struct field order (`player` before `player_move`); for `Enc<Mxe, GameMoves>`, the stored nonce then the account slice. The slice starts at offset 8 to skip the Anchor discriminator, so `moves` must remain the first field of `RPSGame`.
+- Rejected submissions are silent: a move above 2 or a write to an already-filled slot leaves state unchanged with no error; the problem only surfaces when `compare_moves` reports "Invalid Move".
 
-### The Asynchronous Information Hiding Problem
+## Limitations
 
-**Conceptual Challenge**: Rock Paper Scissors requires both players to commit to moves without seeing the opponent's choice. Online, players submit asynchronously - Player 1 first, then Player 2. On public blockchains, Player 2 can see Player 1's move before submitting their own.
+- The signer check does not bind a signer to a slot: the slot claimed comes from the encrypted `player` field, so either registered player could fill the opponent's empty slot.
+- Moves must finalize sequentially: queuing captures the current nonce and ciphertexts, so a second move queued before the first finalizes computes over stale state.
+- No timeout or account closure: if one player never moves, the game stays open indefinitely, and the pairing (`player_a`, `player_b`, game id) is public.
 
-**Traditional solutions**:
-- **Commit-reveal**: Submit hash of move, then reveal. Problem: With only 3 options (rock/paper/scissors), attackers can precompute all possible hashes and reverse them.
-- **Trusted referee**: Third party collects moves. Problem: Referee can peek or leak.
-- **Time locks**: Strict submission windows. Problem: Network latency, timezone issues.
-
-**The Question**: Can we hide moves on a public blockchain to enable fair asynchronous gameplay?
-
-### The Encrypted State Pattern
-
-```rust
-pub struct GameMoves {
-    player_a_move: u8,  // 0=Rock, 1=Paper, 2=Scissors, 3=Not submitted yet
-    player_b_move: u8,
-}
-```
-
-Stored on-chain as `Enc<Mxe, GameMoves>` - network-encrypted, no one can decrypt.
-
-**Phase 1 - Initialization**:
-```rust
-GameMoves { player_a_move: 3, player_b_move: 3 }  // Both "empty"
-```
-
-**Phase 2 - Player submits move** (inside MPC):
-```rust
-pub fn player_move(
-    players_move_ctxt: Enc<Shared, PlayersMove>,
-    game_ctxt: Enc<Mxe, GameMoves>,
-) -> Enc<Mxe, GameMoves> {
-    let players_move = players_move_ctxt.to_arcis();
-    let mut game_moves = game_ctxt.to_arcis();
-
-    // Validate: player hasn't moved yet (3 = invalid move, used as "empty" marker)
-    if players_move.player == 0 && game_moves.player_a_move == 3 && players_move.player_move < 3 {
-        game_moves.player_a_move = players_move.player_move;  // Update encrypted state
-    }
-    // Similar logic for player B...
-
-    game_ctxt.owner.from_arcis(game_moves)  // Return updated encrypted moves
-}
-```
-
-**Phase 3 - Comparison** (only after both submitted):
-```rust
-pub fn compare_moves(game_ctxt: Enc<Mxe, GameMoves>) -> u8 {
-    let game_moves = game_ctxt.to_arcis();
-
-    if game_moves.player_a_move == 3 || game_moves.player_b_move == 3 {
-        return 3;  // Error: incomplete game
-    }
-
-    // Determine winner based on Rock-Paper-Scissors logic...
-    result.reveal()  // Only reveal winner (0=tie, 1=A wins, 2=B wins)
-}
-```
+See also: [Input/output](https://docs.arcium.com/developers/arcis/input-output) · **Next:** [Rock Paper Scissors vs House](../against-house/)

--- a/rock_paper_scissors/against-player/README.md
+++ b/rock_paper_scissors/against-player/README.md
@@ -1,6 +1,6 @@
 # Rock Paper Scissors vs Player — asynchronous hidden moves
 
-Two players submit rock paper scissors moves at different times, each encrypted client-side and merged into MXE-owned game state that no individual party can decrypt. Neither player, the program, nor any single node ever sees a move; only the final outcome is revealed.
+Two players submit rock paper scissors moves at different times, each encrypted client-side and merged into MXE-owned game state that no individual party can decrypt. Neither player can see the other's move before both commit; the final outcome lets each infer the other's move.
 
 **Use this pattern when** multiple parties submit hidden inputs asynchronously and only the result of comparing them should become public: sealed matches, blind negotiations, simultaneous-commitment games.
 
@@ -11,13 +11,13 @@ Two players submit rock paper scissors moves at different times, each encrypted 
 3. Inside MPC, the circuit writes the move into its slot only if the slot is still empty and the move is valid, then returns re-encrypted state; the callback overwrites `RPSGame` with the new ciphertexts and nonce.
 4. Once both slots are filled, anyone calls `compare_moves`. The circuit reveals a single `u8` outcome and the callback emits it as a `CompareMovesEvent` ("Tie", "Player A Wins", "Player B Wins", or "Invalid Move" if a slot was still empty).
 
-Moves stay MXE-owned end to end: each player knows only their own move, and the public learns only the outcome.
+Moves stay MXE-owned end to end and are never published directly. The public learns only the outcome; each player can combine it with their own move to infer the other's.
 
 ## Concepts demonstrated
 
 - Client-encrypted input merged into MXE-owned state: `player_move` takes `Enc<Shared, PlayersMove>` alongside `Enc<Mxe, GameMoves>`, the same shape as the order book in [Input/output](https://docs.arcium.com/developers/arcis/input-output).
 - Passing stored ciphertexts back into MPC: `ArgBuilder`'s `account` method references the `RPSGame` account so the circuit computes over previously stored encrypted state ([Invoking computations](https://docs.arcium.com/developers/program)).
-- Sentinel-guarded writes: "has this player already moved" is decided inside the circuit by comparing against the sentinel, so submission status never leaks.
+- Sentinel-guarded writes: "has this player already moved" is decided inside the circuit by comparing against the sentinel, so slot occupancy and guarded-write success remain hidden.
 
 ## Run
 
@@ -42,7 +42,7 @@ Setup and troubleshooting: [repo README](../../README.md#running-an-example).
 ## Limitations
 
 - The signer check does not bind a signer to a slot: the slot claimed comes from the encrypted `player` field, so either registered player could fill the opponent's empty slot.
-- Moves must finalize sequentially: queuing captures the current nonce and ciphertexts, so a second move queued before the first finalizes computes over stale state.
+- Moves must finalize sequentially: the nonce is fixed when queueing while account ciphertexts are fetched during computation, so overlapping moves can use incompatible state versions or overwrite an update.
 - No timeout or account closure: if one player never moves, the game stays open indefinitely, and the pairing (`player_a`, `player_b`, game id) is public.
 
 See also: [Input/output](https://docs.arcium.com/developers/arcis/input-output) · **Next:** [Rock Paper Scissors vs House](../against-house/)

--- a/rock_paper_scissors/against-player/encrypted-ixs/src/lib.rs
+++ b/rock_paper_scissors/against-player/encrypted-ixs/src/lib.rs
@@ -1,30 +1,40 @@
+//! Circuits for two-player rock paper scissors. Game state lives in
+//! `Enc<Mxe, GameMoves>`, so neither player can read the other's move;
+//! only `compare_moves` reveals anything. See README.md for the full flow.
+
 use arcis::*;
 
 #[encrypted]
 mod circuits {
     use arcis::*;
 
-    // Consider 0 - Rock, 1 - Paper, 2 - Scissors
+    /// Both players' moves (0 = Rock, 1 = Paper, 2 = Scissors);
+    /// `3` marks an empty slot.
     pub struct GameMoves {
         player_a_move: u8,
         player_b_move: u8,
     }
 
+    /// Creates game state with both slots empty. Reveals nothing.
     #[instruction]
     pub fn init_game() -> Enc<Mxe, GameMoves> {
         let game_moves = GameMoves {
-            player_a_move: 3, // Moves are 0-2, so 3 is invalid
-            player_b_move: 3, // Moves are 0-2, so 3 is invalid
+            player_a_move: 3,
+            player_b_move: 3,
         };
 
         Mxe::get().from_arcis(game_moves)
     }
 
+    /// A player's submission: `player` selects the slot (0 = A, 1 = B),
+    /// `player_move` is the move (0-2).
     pub struct PlayersMove {
         player: u8,
         player_move: u8,
     }
 
+    /// Writes the move into its slot if the slot is empty and the move is
+    /// valid; otherwise returns the state unchanged. Reveals nothing.
     #[instruction]
     pub fn player_move(
         players_move_ctxt: Enc<Shared, PlayersMove>,
@@ -33,7 +43,6 @@ mod circuits {
         let players_move = players_move_ctxt.to_arcis();
         let mut game_moves = game_ctxt.to_arcis();
 
-        // Check which player is moving, if the player hasn't played their move yet, and the move is valid
         if players_move.player == 0 && game_moves.player_a_move == 3 && players_move.player_move < 3
         {
             game_moves.player_a_move = players_move.player_move;
@@ -47,11 +56,12 @@ mod circuits {
         game_ctxt.owner.from_arcis(game_moves)
     }
 
+    /// Reveals only the outcome: 0 tie, 1 player A wins, 2 player B wins,
+    /// 3 at least one slot still empty. The moves themselves stay encrypted.
     #[instruction]
     pub fn compare_moves(game_ctxt: Enc<Mxe, GameMoves>) -> u8 {
         let game_moves = game_ctxt.to_arcis();
 
-        // 0 - tie, 1 - player A wins, 2 - player B wins, 3 - invalid move
         let result = if game_moves.player_a_move == 3 || game_moves.player_b_move == 3 {
             3 // Invalid - at least one player hasn't moved
         } else if game_moves.player_a_move == game_moves.player_b_move {

--- a/rock_paper_scissors/against-player/encrypted-ixs/src/lib.rs
+++ b/rock_paper_scissors/against-player/encrypted-ixs/src/lib.rs
@@ -1,6 +1,7 @@
 //! Circuits for two-player rock paper scissors. Game state lives in
-//! `Enc<Mxe, GameMoves>`, so neither player can read the other's move;
-//! only `compare_moves` reveals anything. See README.md for the full flow.
+//! `Enc<Mxe, GameMoves>`, so neither player can read the other's move before
+//! commitment. `compare_moves` reveals an outcome from which each player can infer
+//! the other move. See README.md for the full flow.
 
 use arcis::*;
 

--- a/rock_paper_scissors/against-player/programs/rock_paper_scissors/src/lib.rs
+++ b/rock_paper_scissors/against-player/programs/rock_paper_scissors/src/lib.rs
@@ -1,3 +1,12 @@
+//! Two-player rock paper scissors with MXE-encrypted moves. Stateful: the
+//! `RPSGame` PDA holds the player pubkeys plus the encrypted `GameMoves`
+//! ciphertexts, which `player_move` and `compare_moves` pass back into MPC
+//! by account reference.
+//!
+//! Byte layout read via `ArgBuilder::account`: offset 8 skips the Anchor
+//! discriminator; the next 64 bytes are `moves` (two 32-byte ciphertexts),
+//! so `moves` must stay the first field of `RPSGame`.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 use arcium_client::idl::arcium::types::CallbackAccount;
@@ -17,6 +26,8 @@ pub mod rock_paper_scissors {
         Ok(())
     }
 
+    /// Creates the `RPSGame` PDA for the two players and queues the
+    /// `init_game` circuit to produce empty encrypted game state.
     pub fn init_game(
         ctx: Context<InitGame>,
         computation_offset: u64,
@@ -53,6 +64,7 @@ pub mod rock_paper_scissors {
         Ok(())
     }
 
+    /// Stores the initial `GameMoves` ciphertexts and nonce in `RPSGame`.
     #[arcium_callback(encrypted_ix = "init_game")]
     pub fn init_game_callback(
         ctx: Context<InitGameCallback>,
@@ -82,6 +94,8 @@ pub mod rock_paper_scissors {
         Ok(())
     }
 
+    /// Submits one player's encrypted move; only `player_a` or `player_b`
+    /// may sign. Queues the `player_move` circuit over the stored state.
     pub fn player_move(
         ctx: Context<PlayerMove>,
         computation_offset: u64,
@@ -96,6 +110,9 @@ pub mod rock_paper_scissors {
             ErrorCode::NotAuthorized
         );
 
+        // Arg order mirrors the circuit signature: the Enc<Shared, PlayersMove>
+        // input (pubkey, nonce, ciphertexts in field order), then the
+        // Enc<Mxe, GameMoves> state (stored nonce, `moves` bytes at offset 8).
         let args = ArgBuilder::new()
             .x25519_pubkey(pub_key)
             .plaintext_u128(nonce)
@@ -126,6 +143,7 @@ pub mod rock_paper_scissors {
         Ok(())
     }
 
+    /// Overwrites `RPSGame` with the re-encrypted moves and the new nonce.
     #[arcium_callback(encrypted_ix = "player_move")]
     pub fn player_move_callback(
         ctx: Context<PlayerMoveCallback>,
@@ -155,6 +173,8 @@ pub mod rock_paper_scissors {
         Ok(())
     }
 
+    /// Queues the `compare_moves` circuit over the stored state; the outcome
+    /// is revealed in the callback.
     pub fn compare_moves(ctx: Context<CompareMoves>, computation_offset: u64) -> Result<()> {
         let args = ArgBuilder::new()
             .plaintext_u128(ctx.accounts.rps_game.nonce)
@@ -178,6 +198,7 @@ pub mod rock_paper_scissors {
         Ok(())
     }
 
+    /// Emits the revealed outcome as a `CompareMovesEvent`.
     #[arcium_callback(encrypted_ix = "compare_moves")]
     pub fn compare_moves_callback(
         ctx: Context<CompareMovesCallback>,

--- a/rock_paper_scissors/against-player/tests/rock_paper_scissors.ts
+++ b/rock_paper_scissors/against-player/tests/rock_paper_scissors.ts
@@ -1,3 +1,11 @@
+/**
+ * Flow: init comp defs -> init_game -> player A move -> player B move ->
+ * compare_moves -> CompareMovesEvent with the revealed outcome.
+ *
+ * Unique here: two players each derive their own x25519 shared secret with
+ * the MXE and update the same encrypted state, so every move must await
+ * finalization before the next is queued against the stored nonce.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey, Keypair } from "@solana/web3.js";
@@ -28,7 +36,6 @@ import * as os from "os";
 import { expect } from "chai";
 
 describe("RockPaperScissors", () => {
-  // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace
     .RockPaperScissors as Program<RockPaperScissors>;
@@ -58,7 +65,6 @@ describe("RockPaperScissors", () => {
   const arciumEnv = getArciumEnv();
   const clusterAccount = getClusterAccAddress(arciumEnv.arciumClusterOffset);
 
-  // Combined test suite for Rock Paper Scissors game
   it("Tests the complete Rock Paper Scissors game flow", async () => {
     const owner = readKpJson(`${os.homedir()}/.config/solana/id.json`);
     const playerA = Keypair.generate();
@@ -72,7 +78,6 @@ describe("RockPaperScissors", () => {
 
     console.log("MXE x25519 pubkey is", mxePublicKey);
 
-    // Step 1: Initialize computation definitions
     console.log("Initializing init_game computation definition");
     const initGameSig = await initInitGameCompDef(program, owner);
     console.log(
@@ -94,7 +99,6 @@ describe("RockPaperScissors", () => {
       compareMovesSig
     );
 
-    // Step 2: Play a complete game with two players
     console.log("\n--- Playing a complete game with two players ---");
 
     // Generate encryption keys for Player A
@@ -115,7 +119,6 @@ describe("RockPaperScissors", () => {
     );
     const playerBCipher = new RescueCipher(playerBSharedSecret);
 
-    // Initialize a new game
     const gameId = 1;
 
     const initComputationOffset = new anchor.BN(randomBytes(8), "hex");
@@ -162,7 +165,6 @@ describe("RockPaperScissors", () => {
     );
     console.log("Init game finalize signature:", initGameFinalizeSig);
 
-    // Airdrop funds to Player A
     console.log("Airdropping funds to Player A");
     const airdropPlayerATx = await provider.connection.requestAirdrop(
       playerA.publicKey,
@@ -177,7 +179,6 @@ describe("RockPaperScissors", () => {
     });
     console.log("Funds airdropped to Player A");
 
-    // Player A makes a move (Rock)
     const playerAMove = 0; // Rock
     const playerAId = 0;
     const playerANonce = randomBytes(16);
@@ -238,7 +239,6 @@ describe("RockPaperScissors", () => {
     );
     console.log("Player A move finalize signature:", playerAMoveFinalizeSig);
 
-    // Airdrop funds to Player B
     console.log("Airdropping funds to Player B");
     const airdropPlayerBTx = await provider.connection.requestAirdrop(
       playerB.publicKey,
@@ -253,7 +253,6 @@ describe("RockPaperScissors", () => {
     });
     console.log("Funds airdropped to Player B");
 
-    // Player B makes a move (Scissors)
     const playerBMove = 2; // Scissors
     const playerBId = 1;
     const playerBNonce = randomBytes(16);
@@ -314,7 +313,6 @@ describe("RockPaperScissors", () => {
     );
     console.log("Player B move finalize signature:", playerBMoveFinalizeSig);
 
-    // Compare moves to determine the winner
     const gameEventPromise = awaitEvent("compareMovesEvent");
 
     const compareComputationOffset = new anchor.BN(randomBytes(8), "hex");
@@ -365,7 +363,6 @@ describe("RockPaperScissors", () => {
     // Verify the result (Rock beats Scissors, so Player A wins)
     expect(gameEvent.result).to.equal("Player A Wins");
 
-    // Step 3: Test unauthorized player trying to make a move
     console.log("\n--- Testing unauthorized player ---");
 
     // Generate new encryption keys for this test
@@ -381,7 +378,6 @@ describe("RockPaperScissors", () => {
     );
     const unauthorizedCipher = new RescueCipher(unauthorizedSharedSecret);
 
-    // Initialize a new game
     const gameId2 = new anchor.BN(Date.now());
 
     const initComputationOffset2 = new anchor.BN(randomBytes(8), "hex");
@@ -428,7 +424,6 @@ describe("RockPaperScissors", () => {
     );
     console.log("Init game finalize signature:", initGameFinalizeSig2);
 
-    // Airdrop funds to unauthorized player
     console.log("Airdropping funds to unauthorized player");
     const airdropUnauthorizedTx = await provider.connection.requestAirdrop(
       unauthorizedPlayer.publicKey,
@@ -443,7 +438,6 @@ describe("RockPaperScissors", () => {
     });
     console.log("Funds airdropped to unauthorized player");
 
-    // Unauthorized player tries to make a move
     const unauthorizedMove = 1; // Paper
     const unauthorizedNonce = randomBytes(16);
     const unauthorizedCiphertext = unauthorizedCipher.encrypt(
@@ -493,15 +487,12 @@ describe("RockPaperScissors", () => {
           commitment: "confirmed",
         });
 
-      // If we get here, the test should fail because unauthorized player should not be able to make a move
       expect.fail("Unauthorized player was able to make a move");
     } catch (error) {
       console.log("Expected error caught:", error.message);
-      // Test passes if we catch an error
       expect(error).to.be.an("error");
     }
 
-    // Step 4: Test multiple game scenarios
     console.log("\n--- Testing multiple game scenarios ---");
 
     // Generate encryption keys for multiple game scenarios
@@ -517,7 +508,6 @@ describe("RockPaperScissors", () => {
     );
     const scenarioCipher = new RescueCipher(scenarioSharedSecret);
 
-    // Play multiple games
     const games = [
       { player: 0, house: 0 }, // Rock vs Rock (Tie)
       { player: 0, house: 2 }, // Rock vs Scissors (Win)
@@ -532,7 +522,6 @@ describe("RockPaperScissors", () => {
         `\n--- Testing game scenario: Player ${game.player} vs House ${game.house} ---`
       );
 
-      // Initialize a new game for this scenario
       const scenarioGameId = new anchor.BN(
         Date.now() + Math.floor(Math.random() * 1000)
       );
@@ -581,7 +570,6 @@ describe("RockPaperScissors", () => {
       );
       console.log("Init game finalize signature:", initGameFinalizeSig);
 
-      // Player A makes a move
       const playerAMoveNonce = randomBytes(16);
       const playerAMoveCiphertext = playerACipher.encrypt(
         [BigInt(0), BigInt(game.player)],
@@ -640,7 +628,6 @@ describe("RockPaperScissors", () => {
       );
       console.log("Player A move finalize signature:", playerAMoveFinalizeSig);
 
-      // Player B makes a move
       const playerBMoveNonce = randomBytes(16);
       const playerBMoveCiphertext = playerBCipher.encrypt(
         [BigInt(1), BigInt(game.house)],
@@ -699,7 +686,6 @@ describe("RockPaperScissors", () => {
       );
       console.log("Player B move finalize signature:", playerBMoveFinalizeSig);
 
-      // Compare moves to determine the winner
       const gameEventPromise = awaitEvent("compareMovesEvent");
 
       const compareComputationOffset = new anchor.BN(randomBytes(8), "hex");
@@ -749,7 +735,6 @@ describe("RockPaperScissors", () => {
       const gameEvent = await gameEventPromise;
       console.log(`Game result: ${gameEvent.result}`);
 
-      // Verify the result based on the expected outcome
       let expectedResult: string;
       if (game.player === game.house) {
         expectedResult = "Tie";
@@ -766,10 +751,8 @@ describe("RockPaperScissors", () => {
       expect(gameEvent.result).to.equal(expectedResult);
     }
 
-    // Step 5: Test invalid move scenario
     console.log("\n--- Testing invalid move scenario ---");
 
-    // Initialize a new game for this scenario
     const gameId3 = new anchor.BN(
       Date.now() + Math.floor(Math.random() * 1000)
     );
@@ -821,7 +804,6 @@ describe("RockPaperScissors", () => {
       initGameFinalizeSig3
     );
 
-    // Player A makes a valid move (Rock = 0)
     const playerAValidMove = 0;
     const playerAId3 = 0;
     const playerANonce3 = randomBytes(16);
@@ -879,7 +861,6 @@ describe("RockPaperScissors", () => {
     );
     console.log("Player A move finalize signature:", playerAMoveFinalizeSig3);
 
-    // Player B makes an invalid move (4)
     const playerBInvalidMove = 4;
     const playerBId3 = 1;
     const playerBNonce3 = randomBytes(16);
@@ -937,7 +918,6 @@ describe("RockPaperScissors", () => {
     );
     console.log("Player B move finalize signature:", playerBMoveFinalizeSig3);
 
-    // Compare moves
     const gameEventPromise3 = awaitEvent("compareMovesEvent");
 
     const compareComputationOffset3 = new anchor.BN(randomBytes(8), "hex");
@@ -984,12 +964,10 @@ describe("RockPaperScissors", () => {
     const gameEvent3 = await gameEventPromise3;
     console.log(`Game result for invalid move test: ${gameEvent3.result}`);
 
-    // Verify the result is "Invalid Move"
     expect(gameEvent3.result).to.equal("Invalid Move");
   });
 });
 
-// Helper function to read keypair from JSON file
 function readKpJson(path: string): anchor.web3.Keypair {
   const file = fs.readFileSync(path);
   return anchor.web3.Keypair.fromSecretKey(
@@ -997,7 +975,6 @@ function readKpJson(path: string): anchor.web3.Keypair {
   );
 }
 
-// Separate functions for each computation definition type
 async function initInitGameCompDef(
   program: Program<RockPaperScissors>,
   owner: anchor.web3.Keypair

--- a/sealed_bid_auction/README.md
+++ b/sealed_bid_auction/README.md
@@ -1,6 +1,6 @@
 # Sealed-Bid Auction — private bids, public winner
 
-First-price and Vickrey (second-price) auctions where bid amounts stay encrypted end to end. MPC nodes compare each incoming bid against encrypted running state, and only the winner's public key and the payment amount are ever revealed — losing bids stay hidden from other bidders, the auctioneer, and the nodes themselves.
+First-price and Vickrey (second-price) auctions where MPC nodes compare each incoming bid against encrypted running state. The winner's public key and clearing price are revealed; all other bid amounts remain encrypted.
 
 **Use this pattern when** you need to select a maximum (or ranking) over private inputs and reveal only the outcome: auctions, procurement, hiring, matching markets.
 
@@ -11,7 +11,7 @@ First-price and Vickrey (second-price) auctions where bid amounts stay encrypted
 3. After `end_time` the authority calls `close_auction`, then `determine_winner_first_price` or `determine_winner_vickrey` to match the auction type.
 4. The winner circuit decrypts inside MPC and reveals only the winner's pubkey and the clearing price — the top bid in first-price mode, the second-highest bid in Vickrey mode — which the callback emits as `AuctionResolvedEvent`.
 
-Only the winner and the price they pay become public; losing bids, and in Vickrey mode even the winning bid amount, stay encrypted forever.
+The winner and clearing price become public. In a Vickrey auction that price is the second-highest, losing bid; the winning bid and all non-clearing bid amounts remain encrypted.
 
 ## Concepts demonstrated
 
@@ -43,6 +43,9 @@ Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
 - `min_bid` is stored and emitted but never enforced: the program cannot compare an encrypted amount, and the circuit is never given `min_bid`. A production version would pass it to `place_bid` as a plaintext argument and reject low bids in-circuit.
 - No per-bidder limit or deposit: `bid_count` counts bids, not bidders, and in Vickrey mode a bidder's own extra bid can raise the price they pay.
+- Participation and `bid_count` are public through transaction accounts and events, even though bid amounts are encrypted.
+- The encrypted bidder key is not bound to the transaction signer, and the example has no escrow or settlement; it reports a claimed winner but transfers nothing.
+- Bids must finalize sequentially: the state nonce is fixed when queueing while account ciphertexts are fetched during computation, so overlapping bids can use incompatible state versions or overwrite an update.
 - One auction per authority: the `Auction` PDA is seeded only by the authority key, so a second `create_auction` from the same key fails.
 
 See also: [invoking circuits with ArgBuilder](https://docs.arcium.com/developers/program) · **Next:** [Blackjack](../blackjack/)

--- a/sealed_bid_auction/README.md
+++ b/sealed_bid_auction/README.md
@@ -1,164 +1,48 @@
-# Sealed-Bid Auction - Private Bids, Fair Outcomes
+# Sealed-Bid Auction — private bids, public winner
 
-Traditional auction platforms have access to all bids. Even "sealed" bids are only sealed from other bidders - the platform sees everything. This creates opportunities for bid manipulation, information leakage, and requires trusting the auctioneer not to exploit their privileged position.
+First-price and Vickrey (second-price) auctions where bid amounts stay encrypted end to end. MPC nodes compare each incoming bid against encrypted running state, and only the winner's public key and the payment amount are ever revealed — losing bids stay hidden from other bidders, the auctioneer, and the nodes themselves.
 
-This example demonstrates sealed-bid auctions where bid amounts remain encrypted throughout the auction. The platform never sees individual bid values - only the final winner and payment amount are revealed.
+**Use this pattern when** you need to select a maximum (or ranking) over private inputs and reveal only the outcome: auctions, procurement, hiring, matching markets.
 
-## Why are sealed-bid auctions hard?
+## How it works
 
-Transparent blockchain architectures conflict with bid privacy requirements:
+1. `create_auction` stores the type (`FirstPrice` or `Vickrey`), `min_bid`, and `end_time` in the `Auction` PDA and queues the `init_auction_state` circuit, whose callback writes a zeroed, MXE-encrypted `AuctionState` into `encrypted_state`.
+2. Each bidder encrypts `{bidder, amount}` client-side and calls `place_bid`. The `place_bid` circuit takes the bid (`Enc<Shared, Bid>`) plus the auction state read straight from the account bytes (`Enc<Mxe, AuctionState>`), updates the highest and second-highest bids inside MPC, and the callback writes the re-encrypted state and fresh `state_nonce` back.
+3. After `end_time` the authority calls `close_auction`, then `determine_winner_first_price` or `determine_winner_vickrey` to match the auction type.
+4. The winner circuit decrypts inside MPC and reveals only the winner's pubkey and the clearing price — the top bid in first-price mode, the second-highest bid in Vickrey mode — which the callback emits as `AuctionResolvedEvent`.
 
-1. **Bid visibility**: All blockchain data is publicly accessible by default - competitors see your bid
-2. **Strategic manipulation**: Visible bids enable last-minute sniping and bid shading
-3. **Platform trust**: Traditional sealed-bid auctions require trusting the auctioneer to not peek at bids or collude with bidders
-4. **Winner determination**: Computing the highest bid without revealing all bid amounts is non-trivial
-5. **Pricing mechanisms**: Supporting different auction types (first-price vs Vickrey) requires tracking both highest and second-highest bids privately
+Only the winner and the price they pay become public; losing bids, and in Vickrey mode even the winning bid amount, stay encrypted forever.
 
-The requirement is determining the auction winner and payment amount without revealing individual bids, while ensuring the process is verifiable and tamper-resistant.
+## Concepts demonstrated
 
-## How Sealed-Bid Auctions Work
+- Encrypted state in an ordinary Anchor account: `Auction.encrypted_state` holds five 32-byte ciphertexts that the cluster reads in place via `ArgBuilder`'s `.account(pubkey, offset, size)` — the byte layout lives in the program module header.
+- `SerializedSolanaPublicKey`: a 32-byte Solana pubkey carried as lo/hi `u128` halves so it fits Arcis field elements ([public key types](https://docs.arcium.com/developers/arcis/types#public-key-types)).
+- Two reveal policies over one encrypted state: `determine_winner_first_price` and `determine_winner_vickrey` read the same `AuctionState` but disclose different fields as the price.
 
-The protocol maintains bid privacy while providing accurate winner determination:
-
-1. **Auction creation**: Authority creates an auction specifying the type (first-price or Vickrey), minimum bid, and end time
-2. **Bid encryption**: Bidders encrypt their bid amounts locally before submission using the MXE public key
-3. **Encrypted comparison**: Arcium nodes compare new bids against the encrypted auction state without decrypting
-4. **State update**: Highest and second-highest bids are tracked in encrypted form on-chain
-5. **Winner revelation**: After the auction closes, only the winner identity and payment amount are revealed - not individual bid values
-6. **Security guarantee**: Arcium's MPC protocol ensures auction integrity even with a dishonest majority - bid values remain private as long as one node is honest
-
-## Running the Example
+## Run
 
 ```bash
-# Install dependencies
-yarn install  # or npm install or pnpm install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite demonstrates complete auction flows for both first-price and Vickrey auction types, including auction creation, encrypted bid submission, and winner determination.
+Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-Bids are encrypted using X25519 key exchange with the MXE public key before submission. The auction state stores five encrypted values on-chain: highest bid, highest bidder (as `SerializedSolanaPublicKey`), second-highest bid, and bid count.
+- `encrypted-ixs/src/lib.rs` — note how `place_bid` keeps highest and second-highest with plain Rust comparisons; MPC evaluates both branches without learning which was taken.
+- `programs/sealed_bid_auction/src/lib.rs` — note how `ENCRYPTED_STATE_OFFSET` pins the ciphertext location and how every state-mutating callback also persists the new `state_nonce`.
+- `tests/sealed_bid_auction.ts` — note how `splitPubkeyToU128s` prepares the bidder key for encryption and how the test waits on the validator clock, not wall time, before `close_auction`.
 
-Key properties:
+## Pitfalls
 
-- **Bid secrecy**: Individual bid amounts remain encrypted throughout the auction lifecycle
-- **Distributed computation**: Arcium nodes jointly compare and update encrypted auction state
-- **Selective revelation**: Only the winner and payment amount are revealed, not the losing bids
+- `place_bid`'s argument order is fixed by the circuit signature: bidder x25519 pubkey, bid nonce, the two bidder-pubkey ciphertexts, the amount ciphertext, then the state nonce and account reference. A reordering fails at decryption time, not at build time.
+- The lifecycle guards are strict: `AuctionNotOpen` and `AuctionEnded` gate `place_bid`, `AuctionNotEnded` gates `close_auction`, and `AuctionNotClosed`, `WrongAuctionType`, and `NoBids` gate the winner instructions.
+- If you reorder or resize `Auction` fields, recompute `ENCRYPTED_STATE_OFFSET`: the cluster reads ciphertexts by raw byte offset, and a stale offset hands the circuit garbage.
 
-## Implementation Details
+## Limitations
 
-### The Sealed Bid Problem
+- `min_bid` is stored and emitted but never enforced: the program cannot compare an encrypted amount, and the circuit is never given `min_bid`. A production version would pass it to `place_bid` as a plaintext argument and reject low bids in-circuit.
+- No per-bidder limit or deposit: `bid_count` counts bids, not bidders, and in Vickrey mode a bidder's own extra bid can raise the price they pay.
+- One auction per authority: the `Auction` PDA is seeded only by the authority key, so a second `create_auction` from the same key fails.
 
-**Conceptual Challenge**: How do you find the maximum value in a set without revealing any individual values?
-
-Traditional approaches all fail:
-
-- **Encrypt then decrypt**: Someone holds the decryption key and can see all bids
-- **Trusted auctioneer**: Requires trusting the platform not to leak or exploit bid information
-- **Commit-reveal**: Bidders can see others' bids before revealing, enabling strategic behavior
-
-**The Question**: Can we compare encrypted bids and track the highest one without ever decrypting individual values?
-
-### The Encrypted Auction State Pattern
-
-Sealed-bid auction demonstrates storing encrypted comparison state in Anchor accounts:
-
-```rust
-pub struct AuctionState {
-    pub highest_bid: u64,
-    pub highest_bidder: SerializedSolanaPublicKey,  // Winner pubkey (lo/hi u128 pair)
-    pub second_highest_bid: u64,  // Required for Vickrey auctions
-    pub bid_count: u16,
-}
-```
-
-**Why `SerializedSolanaPublicKey`?** Solana public keys are 32 bytes, but Arcis field elements are smaller. `SerializedSolanaPublicKey` is a built-in type that handles the lo/hi u128 splitting automatically.
-
-**On-chain storage**: The encrypted state is stored as `[[u8; 32]; 5]` - five 32-byte ciphertexts representing each field.
-
-> Learn more about [Arcis Types](https://docs.arcium.com/developers/arcis/types) for encrypted value handling.
-
-### The Bid Comparison Logic
-
-**MPC instruction** (runs inside encrypted computation):
-
-```rust
-pub fn place_bid(
-    bid_ctxt: Enc<Shared, Bid>,       // Bidder's encrypted bid
-    state_ctxt: Enc<Mxe, AuctionState>, // Current encrypted auction state
-) -> Enc<Mxe, AuctionState> {
-    let bid = bid_ctxt.to_arcis();      // Decrypt in MPC (never exposed)
-    let mut state = state_ctxt.to_arcis();
-
-    if bid.amount > state.highest_bid {
-        // New highest bid - shift current highest to second place
-        state.second_highest_bid = state.highest_bid;
-        state.highest_bid = bid.amount;
-        state.highest_bidder = bid.bidder;
-    } else if bid.amount > state.second_highest_bid {
-        // New second-highest bid
-        state.second_highest_bid = bid.amount;
-    }
-
-    state.bid_count += 1;
-    state_ctxt.owner.from_arcis(state)  // Re-encrypt updated state
-}
-```
-
-**Key insight**: The comparison `bid.amount > state.highest_bid` happens inside MPC - decrypted values never leave the secure environment.
-
-### First-Price vs Vickrey Auctions
-
-This example supports two auction mechanisms with different economic properties:
-
-**First-price auction**: Winner pays their bid amount.
-
-```rust
-pub fn determine_winner_first_price(state_ctxt: Enc<Mxe, AuctionState>) -> AuctionResult {
-    let state = state_ctxt.to_arcis();
-    AuctionResult {
-        winner: state.highest_bidder,
-        payment_amount: state.highest_bid,  // Pay your bid
-    }.reveal()
-}
-```
-
-**Vickrey (second-price) auction**: Winner pays the second-highest bid.
-
-```rust
-pub fn determine_winner_vickrey(state_ctxt: Enc<Mxe, AuctionState>) -> AuctionResult {
-    let state = state_ctxt.to_arcis();
-    AuctionResult {
-        winner: state.highest_bidder,
-        payment_amount: state.second_highest_bid,  // Pay second-highest
-    }.reveal()
-}
-```
-
-**Why Vickrey matters**: In a Vickrey auction, bidding your true valuation is the dominant strategy - you can't benefit from bidding lower (you might lose) or higher (you'd overpay). This incentive-compatibility property, discovered by economist William Vickrey (Nobel Prize 1996), is widely used in ad auctions (Google, Meta) and spectrum auctions.
-
-### When to Use This Pattern
-
-Apply sealed-bid auctions when:
-
-- **Bid privacy is critical**: Prevent competitors from seeing and reacting to bids
-- **Strategic behavior is harmful**: Eliminate sniping, bid shading, and collusion
-- **Verifiable fairness is required**: Prove the winner determination was correct without revealing losing bids
-- **Multiple pricing mechanisms**: Need flexibility between first-price and second-price rules
-
-**Example applications**: NFT auctions, ad bidding systems, procurement contracts, treasury bond auctions, spectrum license sales.
-
-This pattern extends to any scenario requiring private comparison and selection: hiring decisions, grant allocations, or matching markets where selection criteria should remain confidential.
-
-## Known Limitations
-
-**`min_bid` not enforced against encrypted bids.** The `min_bid` field is stored on-chain but never checked -- on-chain validation is impossible (the bid is encrypted), and circuit-side validation would require passing `min_bid` as a plaintext argument. For production, pass `min_bid` into the circuit and compare before updating state.
-
-**No per-bidder deduplication.** A bidder can submit multiple bids. This is non-exploitable: in Vickrey mode, duplicate bids can only increase the second-highest price (hurting the bidder). In first-price mode, the bidder always pays their highest bid regardless. The `bid_count` field reflects total bids, not unique bidders.
+See also: [invoking circuits with ArgBuilder](https://docs.arcium.com/developers/program) · **Next:** [Blackjack](../blackjack/)

--- a/sealed_bid_auction/encrypted-ixs/src/lib.rs
+++ b/sealed_bid_auction/encrypted-ixs/src/lib.rs
@@ -1,6 +1,7 @@
 //! Sealed-bid auction circuits: maintain highest and second-highest bids in an
 //! MXE-encrypted `AuctionState`, then reveal only the winner and clearing price.
-//! Individual bid amounts never leave MPC. Walkthrough: ../../README.md.
+//! Bid amounts other than the revealed clearing price never leave MPC.
+//! Walkthrough: ../../README.md.
 
 use arcis::*;
 

--- a/sealed_bid_auction/encrypted-ixs/src/lib.rs
+++ b/sealed_bid_auction/encrypted-ixs/src/lib.rs
@@ -1,3 +1,7 @@
+//! Sealed-bid auction circuits: maintain highest and second-highest bids in an
+//! MXE-encrypted `AuctionState`, then reveal only the winner and clearing price.
+//! Individual bid amounts never leave MPC. Walkthrough: ../../README.md.
+
 use arcis::*;
 
 #[encrypted]
@@ -21,6 +25,7 @@ mod circuits {
         pub payment_amount: u64,
     }
 
+    /// Produces a zeroed `AuctionState` encrypted for the MXE. Reveals nothing.
     #[instruction]
     pub fn init_auction_state() -> Enc<Mxe, AuctionState> {
         let initial_state = AuctionState {
@@ -32,6 +37,8 @@ mod circuits {
         Mxe::get().from_arcis(initial_state)
     }
 
+    /// Folds one bid into the highest/second-highest tracking. Reveals nothing;
+    /// the updated state is re-encrypted for the MXE.
     #[instruction]
     pub fn place_bid(
         bid_ctxt: Enc<Shared, Bid>,
@@ -53,7 +60,7 @@ mod circuits {
         state_ctxt.owner.from_arcis(state)
     }
 
-    /// Winner pays their bid.
+    /// Reveals the winner and their own bid as the price (first-price rule).
     #[instruction]
     pub fn determine_winner_first_price(state_ctxt: Enc<Mxe, AuctionState>) -> AuctionResult {
         let state = state_ctxt.to_arcis();
@@ -65,7 +72,8 @@ mod circuits {
         .reveal()
     }
 
-    /// Winner pays second-highest bid (incentivizes truthful bidding).
+    /// Reveals the winner and the second-highest bid as the price (Vickrey rule);
+    /// the winning bid amount itself stays encrypted.
     #[instruction]
     pub fn determine_winner_vickrey(state_ctxt: Enc<Mxe, AuctionState>) -> AuctionResult {
         let state = state_ctxt.to_arcis();

--- a/sealed_bid_auction/programs/sealed_bid_auction/src/lib.rs
+++ b/sealed_bid_auction/programs/sealed_bid_auction/src/lib.rs
@@ -1,3 +1,16 @@
+//! Sealed-bid auction program: first-price and Vickrey auctions over an
+//! encrypted `AuctionState` persisted in the `Auction` PDA. Bids are compared
+//! inside MPC; the chain only ever learns the winner and the clearing price.
+//!
+//! Byte layout of `Auction`: the encrypted state starts at offset 77 =
+//! 8 (discriminator) + 1 (bump) + 32 (authority) + 1 (auction_type) +
+//! 1 (status) + 8 (min_bid) + 8 (end_time) + 2 (bid_count) + 16 (state_nonce),
+//! followed by five 32-byte ciphertexts, one per Arcis field element:
+//! highest_bid, highest_bidder lo/hi, second_highest_bid, bid_count.
+//! `place_bid` and both winner instructions pass this range to the circuit via
+//! `ArgBuilder::account`, so the cluster reads the state in place.
+//! Walkthrough: ../../../README.md.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 use arcium_client::idl::arcium::types::CallbackAccount;
@@ -8,7 +21,7 @@ const COMP_DEF_OFFSET_DETERMINE_WINNER_FIRST_PRICE: u32 =
     comp_def_offset("determine_winner_first_price");
 const COMP_DEF_OFFSET_DETERMINE_WINNER_VICKREY: u32 = comp_def_offset("determine_winner_vickrey");
 
-// Auction account byte offset: 8 (discriminator) + 1 + 32 + 1 + 1 + 8 + 8 + 2 + 16 = 77
+// See the module header for the field-by-field derivation of this offset.
 const ENCRYPTED_STATE_OFFSET: u32 = 77;
 const ENCRYPTED_STATE_SIZE: u32 = 32 * 5;
 
@@ -55,6 +68,8 @@ pub mod sealed_bid_auction {
         Ok(())
     }
 
+    /// Creates the `Auction` PDA and queues `init_auction_state` to produce the
+    /// initial encrypted state.
     pub fn create_auction(
         ctx: Context<CreateAuction>,
         computation_offset: u64,
@@ -73,6 +88,7 @@ pub mod sealed_bid_auction {
         auction.bid_count = 0;
         auction.encrypted_state = [[0u8; 32]; 5];
 
+        // Arcium signs the callback with this PDA; persist the bump before queueing.
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
 
         let args = ArgBuilder::new().build();
@@ -131,6 +147,8 @@ pub mod sealed_bid_auction {
         Ok(())
     }
 
+    /// Queues the `place_bid` circuit with the bidder's ciphertexts and the
+    /// current encrypted auction state.
     pub fn place_bid(
         ctx: Context<PlaceBid>,
         computation_offset: u64,
@@ -152,6 +170,8 @@ pub mod sealed_bid_auction {
 
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
 
+        // Order must match the circuit signature: Enc<Shared, Bid> = pubkey +
+        // nonce + ciphertexts, then Enc<Mxe, AuctionState> = nonce + account data.
         let args = ArgBuilder::new()
             .x25519_pubkey(bidder_pubkey)
             .plaintext_u128(nonce)
@@ -201,6 +221,8 @@ pub mod sealed_bid_auction {
 
         let auction_key = ctx.accounts.auction.key();
         let auction = &mut ctx.accounts.auction;
+        // The state was re-encrypted under a fresh nonce; persisting it is what
+        // lets the next computation decrypt the account data.
         auction.encrypted_state = o.ciphertexts;
         auction.state_nonce = o.nonce;
         auction.bid_count = auction
@@ -216,6 +238,7 @@ pub mod sealed_bid_auction {
         Ok(())
     }
 
+    /// Marks the auction `Closed` once `end_time` has passed; no MPC involved.
     pub fn close_auction(ctx: Context<CloseAuction>) -> Result<()> {
         let auction = &mut ctx.accounts.auction;
         require!(
@@ -236,6 +259,7 @@ pub mod sealed_bid_auction {
         Ok(())
     }
 
+    /// Queues the first-price winner circuit; the winner pays their own bid.
     pub fn determine_winner_first_price(
         ctx: Context<DetermineWinnerFirstPrice>,
         computation_offset: u64,
@@ -305,6 +329,7 @@ pub mod sealed_bid_auction {
             Err(_) => return Err(ErrorCode::AbortedComputation.into()),
         };
 
+        // SerializedSolanaPublicKey arrives as lo/hi u128 halves, little-endian.
         let mut winner = [0u8; 32];
         winner[..16].copy_from_slice(&winner_lo.to_le_bytes());
         winner[16..].copy_from_slice(&winner_hi.to_le_bytes());
@@ -324,6 +349,7 @@ pub mod sealed_bid_auction {
         Ok(())
     }
 
+    /// Queues the Vickrey winner circuit; the winner pays the second-highest bid.
     pub fn determine_winner_vickrey(
         ctx: Context<DetermineWinnerVickrey>,
         computation_offset: u64,
@@ -393,6 +419,7 @@ pub mod sealed_bid_auction {
             Err(_) => return Err(ErrorCode::AbortedComputation.into()),
         };
 
+        // SerializedSolanaPublicKey arrives as lo/hi u128 halves, little-endian.
         let mut winner = [0u8; 32];
         winner[..16].copy_from_slice(&winner_lo.to_le_bytes());
         winner[16..].copy_from_slice(&winner_hi.to_le_bytes());

--- a/sealed_bid_auction/programs/sealed_bid_auction/src/lib.rs
+++ b/sealed_bid_auction/programs/sealed_bid_auction/src/lib.rs
@@ -1,6 +1,7 @@
 //! Sealed-bid auction program: first-price and Vickrey auctions over an
 //! encrypted `AuctionState` persisted in the `Auction` PDA. Bids are compared
-//! inside MPC; the chain only ever learns the winner and the clearing price.
+//! inside MPC; the circuits reveal the winner and clearing price, while ordinary
+//! transaction metadata also exposes participants and the number of bids.
 //!
 //! Byte layout of `Auction`: the encrypted state starts at offset 77 =
 //! 8 (discriminator) + 1 (bump) + 32 (authority) + 1 (auction_type) +

--- a/sealed_bid_auction/tests/sealed_bid_auction.ts
+++ b/sealed_bid_auction/tests/sealed_bid_auction.ts
@@ -1,3 +1,13 @@
+/**
+ * Flow: create_auction (queues init_auction_state) -> bidders encrypt
+ * [bidder_lo, bidder_hi, amount] and call place_bid -> validator clock passes
+ * end_time -> close_auction -> determine_winner_first_price or
+ * determine_winner_vickrey -> AuctionResolvedEvent carries winner and price.
+ *
+ * Unique here: bidder pubkeys are split into lo/hi u128s to match
+ * SerializedSolanaPublicKey, and closing waits on the validator clock rather
+ * than wall time so the on-chain end_time check passes deterministically.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey } from "@solana/web3.js";
@@ -28,16 +38,13 @@ import * as os from "os";
 import { expect } from "chai";
 
 /**
- * Splits a 32-byte public key into two u128 values (lo and hi parts).
- * This is required because Arcis encrypts each primitive separately.
+ * Splits a 32-byte pubkey into little-endian lo/hi u128s, matching the
+ * circuit's SerializedSolanaPublicKey field order.
  */
 function splitPubkeyToU128s(pubkey: Uint8Array): { lo: bigint; hi: bigint } {
-  // Lower 128 bits (first 16 bytes)
   const loBytes = pubkey.slice(0, 16);
-  // Upper 128 bits (last 16 bytes)
   const hiBytes = pubkey.slice(16, 32);
 
-  // Convert to bigint (little-endian)
   const lo = deserializeLE(loBytes);
   const hi = deserializeLE(hiBytes);
 
@@ -103,14 +110,13 @@ describe("SealedBidAuction", () => {
   before(async () => {
     owner = readKpJson(`${os.homedir()}/.config/solana/id.json`);
 
-    // Get MXE public key for encryption
     mxePublicKey = await getMXEPublicKeyWithRetry(
       provider as anchor.AnchorProvider,
       program.programId
     );
     console.log("MXE x25519 pubkey is", mxePublicKey);
 
-    // Initialize all computation definitions sequentially (like voting/ed25519)
+    // Comp defs must exist before any computation can be queued.
     if (!compDefsInitialized) {
       console.log("\n=== Initializing Computation Definitions ===\n");
 
@@ -138,18 +144,16 @@ describe("SealedBidAuction", () => {
     it("creates an auction, accepts bids, and determines winner (pays their bid)", async () => {
       console.log("\n=== First-Price Auction Test ===\n");
 
-      // Bidder setup - using owner as bidder for simplicity
       const bidder = owner;
       const bidderPubkey = bidder.publicKey.toBytes();
       const { lo: bidderLo, hi: bidderHi } = splitPubkeyToU128s(bidderPubkey);
 
-      // Create encryption keys for bidder
+      // x25519 ECDH with the MXE key; RescueCipher encrypts under the shared secret.
       const privateKey = x25519.utils.randomSecretKey();
       const publicKey = x25519.getPublicKey(privateKey);
       const sharedSecret = x25519.getSharedSecret(privateKey, mxePublicKey);
       const cipher = new RescueCipher(sharedSecret);
 
-      // Step 1: Create First-Price Auction
       console.log("Step 1: Creating first-price auction...");
       const createComputationOffset = new anchor.BN(randomBytes(8), "hex");
 
@@ -197,7 +201,6 @@ describe("SealedBidAuction", () => {
 
       console.log("   Create auction tx:", createSig);
 
-      // Wait for MPC computation to finalize
       const createFinalizeSig = await awaitComputationFinalization(
         provider as anchor.AnchorProvider,
         createComputationOffset,
@@ -213,7 +216,6 @@ describe("SealedBidAuction", () => {
       );
       expect(auctionCreatedEvent.minBid.toNumber()).to.equal(100);
 
-      // Step 2: Place a bid
       console.log("\nStep 2: Placing bid of 500 lamports...");
       const bidPlacedPromise = awaitEvent("bidPlacedEvent", auctionPDA);
       const bidComputationOffset = new anchor.BN(randomBytes(8), "hex");
@@ -221,7 +223,7 @@ describe("SealedBidAuction", () => {
       const bidAmount = BigInt(500);
       const nonce = randomBytes(16);
 
-      // Encrypt bid data: [bidder_lo, bidder_hi, amount]
+      // Plaintext order must match the circuit's Bid struct: bidder lo, hi, amount.
       const bidPlaintext = [bidderLo, bidderHi, bidAmount];
       const bidCiphertext = cipher.encrypt(bidPlaintext, nonce);
 
@@ -271,7 +273,6 @@ describe("SealedBidAuction", () => {
       console.log("   Bid placed, count:", bidPlacedEvent.bidCount);
       expect(bidPlacedEvent.bidCount).to.equal(1);
 
-      // Step 3: Close auction
       console.log("\nStep 3: Waiting for auction to end...");
       const auctionAccount = await program.account.auction.fetch(auctionPDA);
       const endTime = auctionAccount.endTime.toNumber();
@@ -300,7 +301,6 @@ describe("SealedBidAuction", () => {
       const auctionClosedEvent = await auctionClosedPromise;
       console.log("   Auction closed, bid count:", auctionClosedEvent.bidCount);
 
-      // Step 4: Determine winner (first-price)
       console.log("\nStep 4: Determining winner (first-price)...");
       const auctionResolvedPromise = awaitEvent(
         "auctionResolvedEvent",
@@ -357,10 +357,9 @@ describe("SealedBidAuction", () => {
         "lamports"
       );
 
-      // Verify: In first-price, winner pays their bid (500)
+      // First-price: winner pays their own bid (500).
       expect(auctionResolvedEvent.paymentAmount.toNumber()).to.equal(500);
 
-      // Verify winner matches bidder
       const expectedWinner = Buffer.from(bidderPubkey).toString("hex");
       const actualWinner = Buffer.from(auctionResolvedEvent.winner).toString(
         "hex"
@@ -375,30 +374,26 @@ describe("SealedBidAuction", () => {
     it("creates an auction with multiple bids, winner pays second-highest", async () => {
       console.log("\n=== Vickrey Auction Test ===\n");
 
-      // Use a different seed for this auction to avoid PDA collision
-      // We'll use a separate keypair as authority
+      // The auction PDA is seeded by authority, so a fresh keypair avoids
+      // colliding with the first-price auction's PDA.
       const vickreyAuthority = anchor.web3.Keypair.generate();
 
-      // Fund the new authority
       const fundSig = await provider.connection.requestAirdrop(
         vickreyAuthority.publicKey,
         2 * anchor.web3.LAMPORTS_PER_SOL
       );
       await provider.connection.confirmTransaction(fundSig);
 
-      // Bidder setup
-      const bidder1 = owner; // Bid 1000
+      const bidder1 = owner;
       const bidder1Pubkey = bidder1.publicKey.toBytes();
       const { lo: bidder1Lo, hi: bidder1Hi } =
         splitPubkeyToU128s(bidder1Pubkey);
 
-      // Create encryption keys for bidder1
       const privateKey1 = x25519.utils.randomSecretKey();
       const publicKey1 = x25519.getPublicKey(privateKey1);
       const sharedSecret1 = x25519.getSharedSecret(privateKey1, mxePublicKey);
       const cipher1 = new RescueCipher(sharedSecret1);
 
-      // Step 1: Create Vickrey Auction
       console.log("Step 1: Creating Vickrey auction...");
       const createComputationOffset = new anchor.BN(randomBytes(8), "hex");
 
@@ -461,7 +456,6 @@ describe("SealedBidAuction", () => {
         auctionCreatedEvent.auction.toBase58()
       );
 
-      // Step 2: Place first bid (1000 lamports)
       console.log("\nStep 2: Placing first bid of 1000 lamports...");
       const bidPlaced1Promise = awaitEvent("bidPlacedEvent", vickreyAuctionPDA);
       const bid1ComputationOffset = new anchor.BN(randomBytes(8), "hex");
@@ -515,12 +509,11 @@ describe("SealedBidAuction", () => {
       const bidPlaced1Event = await bidPlaced1Promise;
       console.log("   First bid placed, count:", bidPlaced1Event.bidCount);
 
-      // Step 3: Place second bid (700 lamports) - this becomes second-highest
       console.log("\nStep 3: Placing second bid of 700 lamports...");
       const bidPlaced2Promise = awaitEvent("bidPlacedEvent", vickreyAuctionPDA);
       const bid2ComputationOffset = new anchor.BN(randomBytes(8), "hex");
 
-      // Use same bidder but different bid amount
+      // Same bidder, lower amount: becomes the second-highest bid.
       const bid2Amount = BigInt(700);
       const nonce2 = randomBytes(16);
       const privateKey2 = x25519.utils.randomSecretKey();
@@ -576,7 +569,6 @@ describe("SealedBidAuction", () => {
       console.log("   Second bid placed, count:", bidPlaced2Event.bidCount);
       expect(bidPlaced2Event.bidCount).to.equal(2);
 
-      // Step 4: Close auction
       console.log("\nStep 4: Waiting for auction to end...");
       const vickreyAuctionAccount = await program.account.auction.fetch(
         vickreyAuctionPDA
@@ -611,7 +603,6 @@ describe("SealedBidAuction", () => {
       const auctionClosedEvent = await auctionClosedPromise;
       console.log("   Auction closed, bid count:", auctionClosedEvent.bidCount);
 
-      // Step 5: Determine winner (Vickrey)
       console.log("\nStep 5: Determining winner (Vickrey)...");
       const auctionResolvedPromise = awaitEvent(
         "auctionResolvedEvent",
@@ -669,11 +660,9 @@ describe("SealedBidAuction", () => {
         "lamports"
       );
 
-      // Verify: In Vickrey, winner pays second-highest bid (700)
-      // Winner bid 1000, but pays second-highest (700)
+      // Vickrey: winner bid 1000 but pays the second-highest bid (700).
       expect(auctionResolvedEvent.paymentAmount.toNumber()).to.equal(700);
 
-      // Verify winner matches highest bidder
       const expectedWinner = Buffer.from(bidder1Pubkey).toString("hex");
       const actualWinner = Buffer.from(auctionResolvedEvent.winner).toString(
         "hex"
@@ -701,7 +690,6 @@ describe("SealedBidAuction", () => {
       getArciumProgramId()
     )[0];
 
-    // Fetch MXE account for LUT address
     const arciumProgram = getArciumProgram(provider as anchor.AnchorProvider);
     const mxeAccount = getMXEAccAddress(program.programId);
     const mxeAcc = await arciumProgram.account.mxeAccount.fetch(mxeAccount);
@@ -710,8 +698,7 @@ describe("SealedBidAuction", () => {
       mxeAcc.lutOffsetSlot
     );
 
-    // Map circuit name to the correct init method
-    // Using preflightCommitment to get fresh blockhash for each transaction
+    // preflightCommitment gets a fresh blockhash for each sequential init tx.
     let sig: string;
     switch (circuitName) {
       case "init_auction_state":

--- a/share_medical_records/README.md
+++ b/share_medical_records/README.md
@@ -1,98 +1,48 @@
-# Medical Records - Privacy-Preserving Healthcare Data Sharing
+# Medical Records — re-encrypting data to a new owner
 
-Share your medical records with a new doctor and here's the problem: the platform operator, system administrators, database engineers, and cloud infrastructure provider all have access. You can't control who sees what.
+A patient stores an encrypted medical record on-chain and later shares it with a doctor: the record is decrypted only inside MPC and re-encrypted under the doctor's public key. No platform, node, or observer ever sees the plaintext.
 
-This example demonstrates patient-controlled selective disclosure where you specify exactly which medical information each provider can access.
+**Use this pattern when** data encrypted for one party must become readable by another without any intermediary seeing the plaintext: credential handoffs, compliance disclosures, encrypted data markets.
 
-## What's wrong with healthcare data sharing today?
+## How it works
 
-Medical records in centralized databases face multiple problems: patients have no control over who sees what, and every centralized database is a target for breaches. The system requires trusting multiple third parties not to misuse your data.
+1. `store_patient_data` writes eleven client-encrypted ciphertexts (id, age, gender, blood type, weight, height, five allergy flags) into the `PatientData` PDA — a plain Anchor write, no MPC involved.
+2. To share, the patient calls `share_patient_data` with the recipient's x25519 public key; the stored record is passed to the circuit by account reference.
+3. The `share_patient_data` circuit takes the record as `Enc<Shared, PatientData>` and the recipient as a bare `Shared` owner: `to_arcis()` decrypts inside MPC, `receiver.from_arcis()` re-encrypts.
+4. `share_patient_data_callback` verifies the signed output and emits `ReceivedPatientDataEvent`; the stored record is left untouched.
 
-The challenge is enabling healthcare data sharing while giving patients control over access permissions.
+The patient can still decrypt the stored record, the recipient can decrypt the event, and everyone else sees only ciphertext.
 
-## How Selective Data Sharing Works
+## Concepts demonstrated
 
-The protocol enables patient-controlled data disclosure:
+- [Sealing](https://docs.arcium.com/developers/encryption/sealing): a `Shared` parameter names the new owner; `from_arcis` seals the data to them.
+- On-chain ciphertext as circuit input: `ArgBuilder` `.account()` feeds stored account data to MPC by pubkey, offset, and length.
+- Event-based delivery: the callback emits the re-encrypted record instead of persisting it; the recipient collects it off-chain.
 
-1. **Encrypted storage**: Patient medical records are encrypted and stored on-chain
-2. **Access control**: Patient specifies which data fields to share with which providers
-3. **Selective disclosure**: Arcium network enables transfer of authorized data only
-4. **Provider access**: Authorized providers receive only the specific data fields granted access
-
-The patient maintains granular control over data access. Providers receive only authorized information, while the platform facilitating the transfer operates on encrypted data.
-
-## Running the Example
+## Run
 
 ```bash
-# Install dependencies
-yarn install  # or npm install or pnpm install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite demonstrates patient data encryption, selective authorization configuration, and controlled data disclosure to authorized providers.
+Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-Medical records are encrypted and stored as patient data structures. Access control is enforced through encrypted authorization logic that determines which data fields specific providers can access.
+- `encrypted-ixs/src/lib.rs` — note how the circuit body is two lines; a pure ownership handoff needs no computation on the data.
+- `programs/share_medical_records/src/lib.rs` — note how `ArgBuilder` interleaves pubkeys and nonces to reconstruct both `Shared` values for the circuit.
+- `tests/share_medical_records.ts` — note how the receiver derives their own shared secret with the MXE and decrypts using the nonce carried in the event.
 
-## Implementation Details
+## Pitfalls
 
-### The Selective Sharing Problem
+- `ArgBuilder` order must mirror the circuit signature: receiver pubkey and nonce, then sender pubkey, nonce, and ciphertexts. Wrong order fails decryption inside MPC, not at submit time.
+- The account reference starts at offset 8 to skip Anchor's discriminator; reading from 0 feeds discriminator bytes into the circuit as ciphertext.
+- Decrypt the event with `ReceivedPatientDataEvent.nonce`, not the submitted `receiver_nonce` — the MXE assigns a fresh output nonce.
 
-**Conceptual Challenge**: You want to share medical records with a new doctor, but you want to control exactly who can decrypt your information.
+## Limitations
 
-**The Question**: Can you transfer encrypted data from your key to doctor's key without decrypting it in transit?
+- Sharing is all-or-nothing: the whole `PatientData` struct is re-encrypted. Per-field selective disclosure would need separate circuits.
+- Sharing metadata is public: anyone can see a record was shared and to which key.
+- Delivery is a one-shot event; a recipient not listening at callback time must replay transaction logs.
 
-### The Re-encryption Pattern
-
-```rust
-pub fn share_patient_data(
-    receiver: Shared,                      // Recipient's public key for re-encryption
-    input_ctxt: Enc<Shared, PatientData>,  // Your encrypted data
-) -> Enc<Shared, PatientData> {
-    let input = input_ctxt.to_arcis();     // Decrypt inside MPC
-    receiver.from_arcis(input)             // Re-encrypt for doctor
-}
-```
-
-**What happens**:
-
-1. Your encrypted data enters MPC
-2. Data is decrypted inside the MPC environment
-3. Data is re-encrypted using doctor's public key
-4. Re-encrypted data is emitted in event
-5. Only the doctor can decrypt (they have the private key)
-
-**Key insight**: Data is "handed over" inside MPC—re-encrypted from one key to another without intermediate plaintext exposure.
-
-> See [Input/Output Patterns](https://docs.arcium.com/developers/arcis/input-output) for more on encrypted data transfer.
-
-### Multi-field Encrypted Struct
-
-```rust
-pub struct PatientData {
-    patient_id: u64,
-    age: u8,
-    gender: bool,
-    blood_type: u8,
-    weight: u16,
-    height: u16,
-    allergies: [bool; 5],
-}
-```
-
-Stored as a single encrypted data structure containing 11 fields (352 bytes total). The entire record is encrypted together for on-chain storage.
-
-### When to Use Re-encryption
-
-Apply this pattern when:
-
-- Data encrypted under one key needs to be accessible to another party
-- No single party should see the unencrypted data during transfer
-- Selective disclosure (future: share only age + blood_type, not full record)
-- Examples: credential sharing, encrypted file transfer, confidential data markets
+See also: [Sealing (re-encryption)](https://docs.arcium.com/developers/encryption/sealing) · **Next:** [Sealed-Bid Auction](../sealed_bid_auction/)

--- a/share_medical_records/encrypted-ixs/src/lib.rs
+++ b/share_medical_records/encrypted-ixs/src/lib.rs
@@ -1,9 +1,15 @@
+//! Re-encryption (sealing) circuit: hands a patient's encrypted medical record
+//! to a new owner. The record is decrypted only inside MPC and re-encrypted
+//! under the receiver's public key; no plaintext ever leaves the computation.
+//! See README.md for the full flow.
+
 use arcis::*;
 
 #[encrypted]
 mod circuits {
     use arcis::*;
 
+    /// A patient's medical record, encrypted as eleven field ciphertexts.
     pub struct PatientData {
         pub patient_id: u64,
         pub age: u8,
@@ -14,6 +20,8 @@ mod circuits {
         pub allergies: [bool; 5],
     }
 
+    /// Re-encrypts the patient's record for `receiver`. Reveals nothing:
+    /// the output is ciphertext only the receiver can decrypt.
     #[instruction]
     pub fn share_patient_data(
         receiver: Shared,

--- a/share_medical_records/programs/share_medical_records/src/lib.rs
+++ b/share_medical_records/programs/share_medical_records/src/lib.rs
@@ -1,3 +1,11 @@
+//! Stores a patient's encrypted medical record on-chain and re-encrypts it for
+//! a chosen recipient via MPC, emitting the result as an event.
+//!
+//! The `share_patient_data` circuit reads the record directly from the
+//! `PatientData` account: 8-byte Anchor discriminator, then eleven `[u8; 32]`
+//! ciphertexts (patient_id, age, gender, blood_type, weight, height, five
+//! allergy flags) — 352 bytes of ciphertext starting at offset 8.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 
@@ -9,20 +17,8 @@ declare_id!("671bRuGEhWu7N9tsc38xE9Zp8ABAJaBcZRo29UzsftHg");
 pub mod share_medical_records {
     use super::*;
 
-    /// Stores encrypted patient medical data on-chain.
-    ///
-    /// This function stores patient medical information in encrypted form. All data fields
-    /// are provided as encrypted 32-byte arrays that can only be decrypted by authorized parties.
-    /// The data remains confidential while being stored on the public Solana blockchain.
-    ///
-    /// # Arguments
-    /// * `patient_id` - Encrypted unique identifier for the patient
-    /// * `age` - Encrypted patient age
-    /// * `gender` - Encrypted patient gender information
-    /// * `blood_type` - Encrypted blood type information
-    /// * `weight` - Encrypted patient weight
-    /// * `height` - Encrypted patient height
-    /// * `allergies` - Array of encrypted allergy information (up to 5 entries)
+    /// Stores the patient's client-encrypted record in the `PatientData` PDA.
+    /// A plain Anchor write; no MPC computation is queued.
     pub fn store_patient_data(
         ctx: Context<StorePatientData>,
         patient_id: [u8; 32],
@@ -52,18 +48,8 @@ pub mod share_medical_records {
         Ok(())
     }
 
-    /// Initiates confidential sharing of patient data with a specified receiver.
-    ///
-    /// This function triggers an MPC computation that re-encrypts the patient's medical data
-    /// for a specific receiver. The receiver will be able to decrypt the data using their
-    /// private key, while the data remains encrypted for everyone else. The original
-    /// stored data is not modified and remains encrypted for the original owner.
-    ///
-    /// # Arguments
-    /// * `receiver` - Public key of the authorized recipient
-    /// * `receiver_nonce` - Cryptographic nonce for the receiver's encryption
-    /// * `sender_pub_key` - Sender's public key for the operation
-    /// * `nonce` - Cryptographic nonce for the sender's encryption
+    /// Queues the MPC computation that re-encrypts the stored record for
+    /// `receiver`. The stored data is not modified.
     pub fn share_patient_data(
         ctx: Context<SharePatientData>,
         computation_offset: u64,
@@ -72,6 +58,10 @@ pub mod share_medical_records {
         sender_pub_key: [u8; 32],
         nonce: u128,
     ) -> Result<()> {
+        // Argument order must match the circuit signature: `receiver: Shared`
+        // expands to pubkey + nonce, then `Enc<Shared, PatientData>` expands to
+        // pubkey + nonce + ciphertexts. The ciphertexts are read from the
+        // account, starting at offset 8 to skip the Anchor discriminator.
         let args = ArgBuilder::new()
             .x25519_pubkey(receiver)
             .plaintext_u128(receiver_nonce)
@@ -84,6 +74,7 @@ pub mod share_medical_records {
             )
             .build();
 
+        // Persist the bump before queueing so the callback can verify the signer PDA.
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
 
         queue_computation(
@@ -102,11 +93,8 @@ pub mod share_medical_records {
         Ok(())
     }
 
-    /// Handles the result of the patient data sharing MPC computation.
-    ///
-    /// This callback processes the re-encrypted patient data that has been prepared for
-    /// the specified receiver. It emits an event containing all the medical data fields
-    /// encrypted specifically for the receiver's public key.
+    /// Emits the re-encrypted record as `ReceivedPatientDataEvent`; only the
+    /// receiver can decrypt the ciphertexts, using the nonce from the event.
     #[arcium_callback(encrypted_ix = "share_patient_data")]
     pub fn share_patient_data_callback(
         ctx: Context<SharePatientDataCallback>,

--- a/share_medical_records/tests/share_medical_records.ts
+++ b/share_medical_records/tests/share_medical_records.ts
@@ -1,3 +1,12 @@
+/**
+ * Flow: encrypt 11 record fields with the patient's shared secret ->
+ * storePatientData -> sharePatientData(receiver pubkey) -> MPC re-encrypts ->
+ * callback emits receivedPatientDataEvent -> receiver decrypts.
+ *
+ * Unique here: two independent x25519 identities. The receiver
+ * derives their own shared secret with the MXE and decrypts ciphertexts the
+ * patient encrypted, without ever seeing the patient's key.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey } from "@solana/web3.js";
@@ -28,7 +37,6 @@ import * as os from "os";
 import { expect } from "chai";
 
 describe("ShareMedicalRecords", () => {
-  // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace
     .ShareMedicalRecords as Program<ShareMedicalRecords>;
@@ -176,6 +184,7 @@ describe("ShareMedicalRecords", () => {
     );
     console.log("Finalize sig is ", finalizeSig);
 
+    // The receiver's own key exchange with the MXE; the patient's key plays no part.
     const receiverSharedSecret = x25519.getSharedSecret(
       receiverSecretKey,
       mxePublicKey
@@ -184,7 +193,7 @@ describe("ShareMedicalRecords", () => {
 
     const receivedPatientDataEvent = await receivedPatientDataEventPromise;
 
-    // Decrypt all patient data fields
+    // Decrypt with the nonce from the event: the MXE assigns a fresh output nonce.
     const decryptedFields = receiverCipher.decrypt(
       [
         receivedPatientDataEvent.patientId,
@@ -198,7 +207,6 @@ describe("ShareMedicalRecords", () => {
       new Uint8Array(receivedPatientDataEvent.nonce)
     );
 
-    // Verify all fields match the original data
     expect(decryptedFields[0]).to.equal(patientData[0], "Patient ID mismatch");
     expect(decryptedFields[1]).to.equal(patientData[1], "Age mismatch");
     expect(decryptedFields[2]).to.equal(patientData[2], "Gender mismatch");
@@ -206,7 +214,6 @@ describe("ShareMedicalRecords", () => {
     expect(decryptedFields[4]).to.equal(patientData[4], "Weight mismatch");
     expect(decryptedFields[5]).to.equal(patientData[5], "Height mismatch");
 
-    // Verify allergies
     for (let i = 0; i < 5; i++) {
       expect(decryptedFields[6 + i]).to.equal(
         patientData[6 + i],

--- a/voting/README.md
+++ b/voting/README.md
@@ -1,172 +1,67 @@
-# Voting - Private Ballots, Public Results
+# Voting — private ballots, public results
 
-Blockchain transparency makes voting dangerous: visible votes enable vote buying (prove your vote, get paid) and coercion. Encrypt the ballots? Whoever holds the decryption key to count them can still see every vote - and potentially sell or leak that data. Traditional encryption just shifts who holds the power.
+A poll where votes are encrypted on the voter's machine and never decrypted: MPC nodes
+add each ballot to encrypted counters, and only the poll authority can reveal the
+outcome, as a single boolean rather than the tallies.
 
-This example demonstrates tallying votes without decrypting individual ballots. Votes stay encrypted throughout - only aggregate results are revealed.
+**Use this pattern when** you need to aggregate private inputs over time and reveal
+only the aggregate: surveys, leaderboards, confidential analytics.
 
-## Why is blockchain voting hard?
+## How it works
 
-Transparent blockchain architectures conflict with ballot secrecy requirements:
+1. `create_new_poll` initializes two encrypted `u64` counters (`init_vote_stats`
+   circuit) and stores the ciphertexts in the `PollAccount` PDA.
+2. Each voter encrypts a boolean client-side and calls `vote`. The circuit takes the
+   client-encrypted ballot (`Enc<Shared, UserVote>`) and the cluster-owned tallies
+   (`Enc<Mxe, VoteStats>`), increments the right counter inside MPC, and returns
+   re-encrypted tallies; the plaintext never leaves the computation.
+3. A `VoterRecord` PDA (seeded by poll and voter) is created on first vote, so a
+   second vote fails at the account level.
+4. The poll authority calls `reveal_result`, which decrypts inside MPC and reveals
+   only whether yes votes exceed no votes.
 
-1. **Transaction visibility**: All blockchain data is publicly accessible by default
-2. **Ballot privacy**: People may not want peers, family, or colleagues knowing how they voted on sensitive issues - votes need to stay private to prevent social pressure and judgment
-3. **Vote buying**: If you can prove how you voted, someone can pay you to vote a certain way and verify you followed through
-4. **Public tallying**: Everyone needs to be able to check that the final count is correct, without seeing how individual people voted
+No party, not even the authority or an individual node, sees a ballot or the
+running tally.
 
-The requirement is computing aggregate vote tallies without revealing individual ballots, while providing accurate and tamper-resistant final counts.
+## Concepts demonstrated
 
-## How Private Voting Works
+- Persistent encrypted state: `PollAccount.vote_state` holds the tally ciphertexts,
+  passed to the circuit by byte offset via `ArgBuilder` ([invoking a computation](https://docs.arcium.com/developers/program)).
+- Mixed ownership in one circuit: `Enc<Shared, UserVote>` ballot, `Enc<Mxe, VoteStats>`
+  tallies, re-encrypted via `owner.from_arcis` ([encryption overview](https://docs.arcium.com/developers/encryption)).
+- Wallet-derived encryption keys: the test's `deriveEncryptionKey` hashes a wallet
+  signature into an x25519 key, so voters carry no extra key material.
 
-The protocol maintains ballot secrecy while providing accurate results:
-
-1. **Ballot encryption**: Votes are encrypted on the client's computer before submission
-2. **On-chain storage**: Encrypted votes are recorded on the blockchain
-3. **Secure distributed tallying**: Arcium nodes collaboratively compute aggregate totals
-4. **Result publication**: Only aggregate vote counts are revealed, not individual choices
-5. **Security guarantee**: Arcium's MPC protocol preserves ballot secrecy even with a dishonest majority—individual votes remain private as long as one node is honest
-
-## Running the Example
+## Run
 
 ```bash
-# Install dependencies
-yarn install  # or npm install or pnpm install
-
-# Build the program
-arcium build
-
-# Run tests
-arcium test
+yarn install && arcium build && arcium test
 ```
 
-The test suite demonstrates poll creation, encrypted ballot submission, secure distributed tallying, and result verification.
+Setup and troubleshooting: [repo README](../README.md#running-an-example).
 
-## Technical Implementation
+## Key files
 
-Votes are sent as encrypted booleans and stored as encrypted vote counts on-chain (using `Enc<Shared, bool>` in the code). Arcium's confidential instructions enable aggregate computation over encrypted ballots.
+- `encrypted-ixs/src/lib.rs` — note how `reveal_result` reveals a comparison, never
+  the counts.
+- `programs/voting/src/lib.rs` — note how the `vote` handler reads the tallies by
+  byte offset and how the callbacks persist the rotated nonce.
+- `tests/voting.ts` — note how `deriveEncryptionKey` builds the x25519 key from a
+  wallet signature instead of throwaway key material.
 
-Key properties:
+## Pitfalls
 
-- **Ballot secrecy**: Individual votes remain encrypted throughout the tallying process
-- **Distributed computation**: Arcium nodes jointly compute aggregate tallies
-- **Result accuracy**: Aggregate totals are computed correctly despite processing only encrypted data
-- **Double-vote prevention**: A `VoterRecord` PDA (seeded by poll + voter keys) is initialized via Anchor's `init` constraint in the `vote` instruction — a second vote from the same voter fails because the account already exists
+- `InvalidAuthority`: only the wallet that created the poll can call `reveal_result`.
+- `ArgBuilder` order must match the circuit signature: `x25519_pubkey`, nonce, then
+  ciphertext for the ballot; stored nonce plus account reference for the tallies.
+- The account read skips 9 bytes (8-byte discriminator + 1-byte `bump`) to reach
+  `vote_state`; reordering `PollAccount` fields silently feeds garbage to the circuit.
 
-## Implementation Details
+## Limitations
 
-### The Private Tallying Problem
+- Participation is public: `VoterRecord` PDAs and `VoteEvent` show who voted and
+  when; only the ballot content is hidden.
+- No poll close: the authority can reveal at any time, and small tallies leak
+  ballots (a one-vote poll's result is that voter's ballot). Ties reveal as `false`.
 
-**Conceptual Challenge**: How do you count votes without seeing individual ballots?
-
-Traditional approaches all fail:
-
-- **Encrypt then decrypt**: Someone holds the decryption key and can see votes
-- **Trusted counter**: Requires trusting the tallying authority
-
-**The Question**: Can we compute "yes_votes + no_votes" on encrypted data without ever decrypting individual votes?
-
-### The Encrypted State Pattern
-
-Voting demonstrates storing encrypted counters directly in Anchor accounts:
-
-```rust
-#[account]
-pub struct PollAccount {
-    pub vote_state: [[u8; 32]; 2],  // Two 32-byte ciphertexts
-    pub nonce: u128,                // Cryptographic nonce
-    pub authority: Pubkey,          // Who can reveal results
-    // ... other fields
-}
-```
-
-**What's stored**: Two encrypted `u64` counters (yes, no) as raw ciphertexts.
-
-### Reading Encrypted Account Data
-
-Arx nodes need precise byte locations to read encrypted data from accounts and deserialize it into the proper MPC function arguments.
-
-To specify encrypted account data, provide exact byte offsets:
-
-```rust
-Argument::Account(
-    ctx.accounts.poll_acc.key(),
-    8 + 1,  // Skip: Anchor discriminator (8 bytes) + bump (1 byte)
-    64,     // Read: 2 ciphertexts × 32 bytes = 64 bytes
-)
-```
-
-**Memory layout**:
-
-```
-Byte 0-7:   Anchor discriminator
-Byte 8:     bump
-Byte 9-40:  yes ciphertext (Enc<Mxe, u64>)
-Byte 41-72: no ciphertext (Enc<Mxe, u64>)
-Byte 73+:   other fields...
-```
-
-### The Vote Accumulation Logic
-
-**MPC instruction** (runs inside encrypted computation):
-
-```rust
-pub fn vote(
-    input: Enc<Shared, UserVote>,    // Voter's encrypted choice
-    votes: Enc<Mxe, VoteStats>,      // Current encrypted tallies
-) -> Enc<Mxe, VoteStats> {
-    let input = input.to_arcis();     // Decrypt in MPC (never exposed)
-    let mut votes = votes.to_arcis(); // Decrypt tallies in MPC
-
-    if input.vote {
-        votes.yes += 1;  // Increment happens inside MPC
-    } else {
-        votes.no += 1;
-    }
-
-    votes.owner.from_arcis(votes)  // Re-encrypt updated tallies
-}
-```
-
-**Callback** (runs on-chain after MPC completes):
-
-```rust
-pub fn vote_callback(
-    ctx: Context<VoteCallback>,
-    output: SignedComputationOutputs<VoteOutput>,
-) -> Result<()> {
-    let o = match output.verify_output(
-        &ctx.accounts.cluster_account,
-        &ctx.accounts.computation_account,
-    ) {
-        Ok(VoteOutput { field_0 }) => field_0,
-        Err(_) => return Err(ErrorCode::AbortedComputation.into()),
-    };
-
-    // Save new encrypted tallies + new nonce
-    ctx.accounts.poll_acc.vote_state = o.ciphertexts;
-    ctx.accounts.poll_acc.nonce = o.nonce;
-    Ok(())
-}
-```
-
-> Learn more: [Callback Type Generation](https://docs.arcium.com/developers/program/callback-type-generation), [Input/Output Patterns](https://docs.arcium.com/developers/arcis/input-output)
-
-### Revealing Results
-
-The program restricts result revelation to the poll authority:
-
-```rust
-pub fn reveal_result(votes: Enc<Mxe, VoteStats>) -> bool {
-    let votes = votes.to_arcis();
-    (votes.yes > votes.no).reveal()  // Only reveal comparison
-}
-```
-
-### What This Example Demonstrates
-
-This example shows how to:
-
-- **Store encrypted data in Solana accounts**: Using raw bytes (`[[u8; 32]; 2]`) to persist encrypted values on-chain
-- **Pass encrypted account data to MPC**: Using `Argument::Account()` with precise byte offsets to read encrypted state
-- **Compute on encrypted state over time**: Accumulating encrypted values across multiple transactions (adding new votes to running tallies)
-
-This pattern applies to any scenario requiring private aggregation: voting, surveys, sealed-bid auctions, confidential analytics, and private leaderboards.
+See also: [Shared vs MXE encryption](https://docs.arcium.com/developers/program/callback-type-generation#encryption-types-shared-vs-mxe) · **Next:** [Medical Records](../share_medical_records/)

--- a/voting/README.md
+++ b/voting/README.md
@@ -63,5 +63,8 @@ Setup and troubleshooting: [repo README](../README.md#running-an-example).
   when; only the ballot content is hidden.
 - No poll close: the authority can reveal at any time, and small tallies leak
   ballots (a one-vote poll's result is that voter's ballot). Ties reveal as `false`.
+- Votes must finalize sequentially: the tally nonce is fixed when queueing while
+  account ciphertexts are fetched during computation, so overlapping votes can use
+  incompatible state versions or overwrite an update.
 
 See also: [Shared vs MXE encryption](https://docs.arcium.com/developers/program/callback-type-generation#encryption-types-shared-vs-mxe) · **Next:** [Medical Records](../share_medical_records/)

--- a/voting/encrypted-ixs/src/lib.rs
+++ b/voting/encrypted-ixs/src/lib.rs
@@ -1,42 +1,33 @@
+//! Private voting circuits: `init_vote_stats` zeroes the tally counters, `vote` adds
+//! an encrypted ballot to them, and `reveal_result` discloses only whether yes votes
+//! exceed no votes. Ballots and tallies stay encrypted throughout; see README.md.
+
 use arcis::*;
 
 #[encrypted]
 mod circuits {
     use arcis::*;
 
-    /// Tracks the encrypted vote tallies for a poll.
+    /// Encrypted yes/no tallies for a poll.
     pub struct VoteStats {
         yes: u64,
         no: u64,
     }
 
-    /// Represents a single encrypted vote.
+    /// A single voter's encrypted ballot.
     pub struct UserVote {
         vote: bool,
     }
 
-    /// Initializes encrypted vote counters for a new poll.
-    ///
-    /// Creates a VoteStats structure with zero counts for both yes and no votes.
-    /// The counters remain encrypted and can only be updated through MPC operations.
+    /// Creates zeroed vote counters encrypted to the MXE. Reveals nothing.
     #[instruction]
     pub fn init_vote_stats() -> Enc<Mxe, VoteStats> {
         let vote_stats = VoteStats { yes: 0, no: 0 };
         Mxe::get().from_arcis(vote_stats)
     }
 
-    /// Processes an encrypted vote and updates the running tallies.
-    ///
-    /// Takes an individual vote and adds it to the appropriate counter (yes or no)
-    /// without revealing the vote value. The updated vote statistics remain encrypted
-    /// and can only be revealed by the poll authority.
-    ///
-    /// # Arguments
-    /// * `vote_ctxt` - The encrypted vote to be counted
-    /// * `vote_stats_ctxt` - Current encrypted vote tallies
-    ///
-    /// # Returns
-    /// Updated encrypted vote statistics with the new vote included
+    /// Adds one encrypted ballot to the running tallies and returns them re-encrypted
+    /// to the MXE. Neither the ballot nor the counts are revealed.
     #[instruction]
     pub fn vote(
         vote_ctxt: Enc<Shared, UserVote>,
@@ -45,7 +36,6 @@ mod circuits {
         let user_vote = vote_ctxt.to_arcis();
         let mut vote_stats = vote_stats_ctxt.to_arcis();
 
-        // Increment appropriate counter based on vote value
         if user_vote.vote {
             vote_stats.yes += 1;
         } else {
@@ -55,17 +45,8 @@ mod circuits {
         vote_stats_ctxt.owner.from_arcis(vote_stats)
     }
 
-    /// Reveals the final result of the poll by comparing vote tallies.
-    ///
-    /// Decrypts the vote counters and determines whether the majority voted yes or no.
-    /// Only the final result (majority decision) is revealed, not the actual vote counts.
-    ///
-    /// # Arguments
-    /// * `vote_stats_ctxt` - Encrypted vote tallies to be revealed
-    ///
-    /// # Returns
-    /// * `true` if more people voted yes than no
-    /// * `false` if more people voted no than yes (or tie)
+    /// Reveals a single boolean: whether yes votes exceed no votes (ties are false).
+    /// The counts themselves stay hidden.
     #[instruction]
     pub fn reveal_result(vote_stats_ctxt: Enc<Mxe, VoteStats>) -> bool {
         let vote_stats = vote_stats_ctxt.to_arcis();

--- a/voting/programs/voting/src/lib.rs
+++ b/voting/programs/voting/src/lib.rs
@@ -1,3 +1,12 @@
+//! Confidential voting: yes/no tallies live in `PollAccount` as ciphertexts and are
+//! only ever updated inside MPC. Only the poll authority can reveal the boolean
+//! outcome. Walkthrough: README.md.
+//!
+//! Stateful: circuits read the tallies straight from `PollAccount` bytes via
+//! `ArgBuilder`'s account reference — 8-byte Anchor discriminator, 1-byte `bump`,
+//! then `vote_state` (two 32-byte ciphertexts: yes, no) at offset 9. The offset
+//! breaks if those fields are reordered.
+
 use anchor_lang::prelude::*;
 use arcium_anchor::prelude::*;
 use arcium_client::idl::arcium::types::CallbackAccount;
@@ -17,15 +26,8 @@ pub mod voting {
         Ok(())
     }
 
-    /// Creates a new confidential poll with the given question.
-    ///
-    /// This initializes a poll account and sets up the encrypted vote counters using MPC.
-    /// The vote tallies are stored in encrypted form and can only be revealed by the poll authority.
-    /// All individual votes remain completely confidential throughout the voting process.
-    ///
-    /// # Arguments
-    /// * `id` - Unique identifier for this poll
-    /// * `question` - The poll question voters will respond to
+    /// Creates a poll and queues `init_vote_stats` to produce encrypted zeroed
+    /// counters; the callback stores them in `poll_acc`.
     pub fn create_new_poll(
         ctx: Context<CreateNewPoll>,
         computation_offset: u64,
@@ -34,7 +36,6 @@ pub mod voting {
     ) -> Result<()> {
         msg!("Creating a new poll");
 
-        // Initialize the poll account with the provided parameters
         ctx.accounts.poll_acc.question = question;
         ctx.accounts.poll_acc.bump = ctx.bumps.poll_acc;
         ctx.accounts.poll_acc.id = id;
@@ -43,9 +44,10 @@ pub mod voting {
 
         let args = ArgBuilder::new().build();
 
+        // The MXE derives this PDA at runtime; the bump must be persisted before
+        // queue_computation.
         ctx.accounts.sign_pda_account.bump = ctx.bumps.sign_pda_account;
 
-        // Initialize encrypted vote counters (yes/no) through MPC
         queue_computation(
             ctx.accounts,
             computation_offset,
@@ -79,6 +81,8 @@ pub mod voting {
             Err(_) => return Err(ErrorCode::AbortedComputation.into()),
         };
 
+        // The MXE rotates the nonce every computation; persist it with the
+        // ciphertexts or the next computation cannot decrypt the tallies.
         ctx.accounts.poll_acc.vote_state = o.ciphertexts;
         ctx.accounts.poll_acc.nonce = o.nonce;
 
@@ -90,16 +94,8 @@ pub mod voting {
         Ok(())
     }
 
-    /// Submits an encrypted vote to the poll.
-    ///
-    /// This function allows a voter to cast their vote (yes/no) in encrypted form.
-    /// The vote is added to the running tally through MPC computation, ensuring
-    /// that individual votes remain confidential while updating the overall count.
-    ///
-    /// # Arguments
-    /// * `vote` - Encrypted vote (true for yes, false for no)
-    /// * `vote_encryption_pubkey` - Voter's public key for encryption
-    /// * `vote_nonce` - Cryptographic nonce for the vote encryption
+    /// Queues the `vote` circuit with the voter's encrypted ballot and the current
+    /// tallies. Initializing `voter_record` here blocks a second vote per voter.
     pub fn vote(
         ctx: Context<Vote>,
         computation_offset: u64,
@@ -108,6 +104,8 @@ pub mod voting {
         vote_encryption_pubkey: [u8; 32],
         vote_nonce: u128,
     ) -> Result<()> {
+        // Argument order must match the circuit signature: Enc<Shared, UserVote> is
+        // pubkey + nonce + ciphertext, then Enc<Mxe, VoteStats> is nonce + account data.
         let args = ArgBuilder::new()
             .x25519_pubkey(vote_encryption_pubkey)
             .plaintext_u128(vote_nonce)
@@ -174,14 +172,8 @@ pub mod voting {
         Ok(())
     }
 
-    /// Reveals the final result of the poll.
-    ///
-    /// Only the poll authority can call this function to decrypt and reveal the vote tallies.
-    /// The MPC computation compares the yes and no vote counts and returns whether
-    /// the majority voted yes (true) or no (false).
-    ///
-    /// # Arguments
-    /// * `id` - The poll ID to reveal results for
+    /// Queues `reveal_result`, which discloses only whether yes votes exceed no
+    /// votes. Restricted to the poll authority.
     pub fn reveal_result(
         ctx: Context<RevealVotingResult>,
         computation_offset: u64,

--- a/voting/tests/voting.ts
+++ b/voting/tests/voting.ts
@@ -1,3 +1,13 @@
+/**
+ * Flow: init comp defs -> create polls (init_vote_stats zeroes encrypted
+ * counters) -> encrypt ballot client-side -> vote -> await finalization (callback
+ * updates encrypted tallies) -> attempt double vote (rejected: VoterRecord PDA
+ * exists) -> reveal_result publishes only the boolean outcome.
+ *
+ * Unique here: the x25519 encryption key is derived from the Solana
+ * wallet (sign a fixed message, SHA-256 the signature), so voters can recover
+ * their encryption key from their wallet alone.
+ */
 import * as anchor from "@anchor-lang/core";
 import { Program } from "@anchor-lang/core";
 import { PublicKey } from "@solana/web3.js";
@@ -50,7 +60,6 @@ function deriveEncryptionKey(
 }
 
 describe("Voting", () => {
-  // Configure the client to use the local cluster.
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Voting as Program<Voting>;
   const provider = anchor.getProvider();
@@ -118,7 +127,6 @@ describe("Voting", () => {
     const sharedSecret = x25519.getSharedSecret(privateKey, mxePublicKey);
     const cipher = new RescueCipher(sharedSecret);
 
-    // Create multiple polls
     for (const POLL_ID of POLL_IDS) {
       const pollComputationOffset = new anchor.BN(randomBytes(8), "hex");
 
@@ -160,8 +168,7 @@ describe("Voting", () => {
       console.log(`Finalize poll ${POLL_ID} sig is `, finalizePollSig);
     }
 
-    // Cast votes for each poll with different outcomes
-    const voteOutcomes = [true, false, true]; // Different outcomes for each poll
+    const voteOutcomes = [true, false, true];
     let firstPollPDA: PublicKey;
     let firstVoterRecordPDA: PublicKey;
     for (let i = 0; i < POLL_IDS.length; i++) {
@@ -244,8 +251,7 @@ describe("Voting", () => {
       );
     }
 
-    // Test double-vote prevention: attempt to vote again on the first poll
-    // Reuse firstPollPDA and firstVoterRecordPDA derived during the voting loop
+    // A second vote on the same poll must fail: the VoterRecord PDA already exists.
     console.log("\n--- Testing double-vote prevention ---");
     const DOUBLE_VOTE_POLL_ID = POLL_IDS[0];
     const doubleVoteNonce = randomBytes(16);
@@ -297,7 +303,6 @@ describe("Voting", () => {
       );
     }
 
-    // Reveal results for each poll
     for (let i = 0; i < POLL_IDS.length; i++) {
       const POLL_ID = POLL_IDS[i];
       const expectedOutcome = voteOutcomes[i];


### PR DESCRIPTION
## Summary
Replaces the verbose, repetitive v0.9.6-era READMEs with a layered structure: the root README owns everything shared (workflow, lifecycle, trust model, troubleshooting), per-example READMEs follow one fixed ~50-line skeleton, and deep material moves into module docs next to the code. Supersedes #70 and #66, whose content was reapplied and re-verified against current source.

## Changes
- Root README: example index table + learning path, single run-workflow section, troubleshooting with named errors, scope disclaimer
- Per-example READMEs: fixed skeleton (How it works / Concepts demonstrated / Run / Key files / Pitfalls / Limitations / Next); no fenced Rust/TS — inline identifiers only, all grep-verified against source
- Rust: `//!` module headers on circuits and programs (byte layouts documented where queue calls read accounts by offset); rustdoc trimmed of `# Arguments`/`# Returns` boilerplate and narration comments; inline comments only at Arcium footguns (ArgBuilder order, byte offsets, sign-PDA bump)
- Tests: one JSDoc flow header per file; narration comments removed, crypto-step comments kept
- Accuracy fixes: dead `Argument::Account` API removed from voting README; wrong move-encoding comment in the RPS-vs-house test corrected (0/1/2, not 1/2/3); false PR #70 claim about in-circuit slot enforcement replaced with an honest limitation

Verified: `cargo check` and `cargo fmt --check` pass on all 8 examples; `tsc --noEmit` clean on edited tests; every README identifier grep-confirmed in its example's source.